### PR TITLE
Add general callbacks as another block/sched mechanism

### DIFF
--- a/blocklib/blocks/include/gnuradio/blocklib/blocks/multiply_const_blk.hpp
+++ b/blocklib/blocks/include/gnuradio/blocklib/blocks/multiply_const_blk.hpp
@@ -9,6 +9,9 @@ namespace blocks {
 template <class T>
 class multiply_const : public sync_block
 {
+
+private:
+
     T d_k;
     const size_t d_vlen;
 
@@ -23,18 +26,26 @@ public:
     virtual work_return_code_t work(std::vector<block_work_input>& work_input,
                                     std::vector<block_work_output>& work_output);
 
-    // const T k();
-    // void set_k(T k);
 
     virtual void on_parameter_change(param_action_base param) override;
     virtual void on_parameter_query(param_action_base& param) override;
+    std::any handle_do_a_bunch_of_things(std::vector<std::any> args)
+    {
+        auto xi = std::any_cast<int>(args[0]);
+        auto yi = std::any_cast<double>(args[1]);
+        auto zi = std::any_cast<std::vector<gr_complex>>(args[2]);
+
+        return std::make_any<double>(xi*yi);
+    }
 
     // These methods should be automatically generated
-    // setters/getters
-
-
+    // setters/getters/callback wrappers
+    double do_a_bunch_of_things(const int x, const double y, const std::vector<gr_complex>& z);
     void set_k(T k);
     T k();
+
+
+
 };
 
 typedef multiply_const<std::int16_t> multiply_const_ss;

--- a/blocklib/blocks/lib/multiply_const_blk.cpp
+++ b/blocklib/blocks/lib/multiply_const_blk.cpp
@@ -23,9 +23,9 @@ void multiply_const<T>::ports_and_params(size_t vlen)
                            port_type_t::STREAM,
                            std::vector<size_t>{ vlen }));
 
-    add_param(param<T>(multiply_const<float>::params::id_k, "k", 1.0));
+    add_param(param<T>(multiply_const<T>::params::id_k, "k", 1.0));
 
-    add_param(param<size_t>(multiply_const<float>::params::id_vlen, "vlen", 1));
+    add_param(param<size_t>(multiply_const<T>::params::id_vlen, "vlen", 1));
 }
 
 template <>

--- a/blocklib/blocks/lib/multiply_const_blk.cpp
+++ b/blocklib/blocks/lib/multiply_const_blk.cpp
@@ -7,6 +7,8 @@
 #include "multiply_const_blk.hpp"
 #include <gnuradio/scheduler.hpp>
 #include <volk/volk.h>
+#include <chrono>
+#include <thread>
 
 namespace gr {
 namespace blocks {
@@ -26,6 +28,10 @@ void multiply_const<T>::ports_and_params(size_t vlen)
     add_param(param<T>(multiply_const<T>::params::id_k, "k", 1.0));
 
     add_param(param<size_t>(multiply_const<T>::params::id_vlen, "vlen", 1));
+
+    register_callback("do_a_bunch_of_things", [this](auto args) {
+        return this->handle_do_a_bunch_of_things(args);
+    });
 }
 
 template <>
@@ -172,6 +178,42 @@ T multiply_const<T>::k()
     }
 
     return d_k;
+}
+
+template <class T>
+double multiply_const<T>::do_a_bunch_of_things(const int x, const double y, const std::vector<gr_complex>& z)
+{
+    // call back to the scheduler if ptr is not null
+    if (p_scheduler) {
+        bool cb_complete = false;
+        int val;
+        p_scheduler->request_callback(
+            alias(),
+            callback_args{
+                "do_a_bunch_of_things",
+                std::vector<std::any>{ std::make_any<int>(x),
+                                       std::make_any<double>(y),
+                                       std::make_any<std::vector<gr_complex>>(z) },
+                std::any(),
+                0 },
+            [&cb_complete, &val](auto cb_args) {
+                cb_complete = true;
+                val = std::any_cast<double>(cb_args.return_val);
+            });
+
+        // block
+        while (!cb_complete) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+
+        std::cout << "callback returned " << val << std::endl;
+
+        return val;
+    }
+    // else go ahead and return parameter value
+    else {
+        return 0;
+    }
 }
 
 template class multiply_const<std::int16_t>;

--- a/blocklib/common/include/gnuradio/blocklib/block.hpp
+++ b/blocklib/common/include/gnuradio/blocklib/block.hpp
@@ -11,13 +11,15 @@
 #include <cstdint>
 #include <string>
 #include <vector>
-
+#include <memory>
+		
 #include <gnuradio/blocklib/block_callbacks.hpp>
 #include <gnuradio/blocklib/block_work_io.hpp>
 #include <gnuradio/blocklib/io_signature.hpp>
 #include <gnuradio/blocklib/node.hpp>
 #include <gnuradio/blocklib/parameter.hpp>
-#include <memory>
+#include <gnuradio/blocklib/callback.hpp>
+
 
 
 namespace gr {
@@ -58,6 +60,8 @@ private:
     bool d_output_multiple_set = false;
     unsigned int d_output_multiple;
 
+    std::map<std::string,block_callback_fcn> _callback_function_map;  // callback_function_map["mult0"]["do_something"](x,y,z)
+
 protected:
     vcolor d_color;
 
@@ -81,6 +85,13 @@ protected:
     void add_param(param_base p) { parameters.add(p); }
 
     std::shared_ptr<scheduler> p_scheduler = nullptr;
+
+    // TODO: register the types
+    void register_callback(const std::string& cb_name, block_callback_fcn fcn)
+    {
+        _callback_function_map[cb_name] = fcn;
+    }
+
 
 public:
     /**
@@ -166,6 +177,9 @@ public:
     {
         throw std::runtime_error("parameter queries not defined for this block");
     }
+
+    std::map<std::string,block_callback_fcn> callbacks() {return _callback_function_map;}
+
 
     void set_scheduler(std::shared_ptr<scheduler> sched) { p_scheduler = sched; }
 };

--- a/blocklib/common/include/gnuradio/blocklib/callback.hpp
+++ b/blocklib/common/include/gnuradio/blocklib/callback.hpp
@@ -1,23 +1,37 @@
 #pragma once
 
+#include <functional>
+#include <queue>
+#include <any>
+#include <vector>
+
 namespace gr {
 
-class callback_base
+struct callback_args
 {
-    // protected:
-    //     uint32_t _id;
-    //     std::any _any_value;
-    //     uint64_t _at_sample;
-
-    // public:
-    //     param_action_base(uint32_t id, std::any any_value, uint64_t at_sample)
-    //         : _id(id), _any_value(any_value), _at_sample(at_sample)
-    //     {
-    //     }
-    //     uint32_t id() { return _id; }
-    //     std::any any_value() { return _any_value; }
-    //     uint64_t at_sample() { return _at_sample; }
+    std::string callback_name;
+    std::vector<std::any> args;
+    std::any return_val;
+    uint64_t at_sample;
 };
 
+
+typedef std::function<std::any(std::vector<std::any>)> block_callback_fcn;
+typedef std::function<void(callback_args)> block_callback_complete_fcn;
+
+struct callback_args_with_callback {
+    std::string block_id;
+    callback_args cb_struct;
+    block_callback_complete_fcn cb_fcn;
+};
+
+
+
+typedef std::queue<block_callback_fcn> block_callback_fcn_queue;
+typedef std::queue<callback_args_with_callback> block_callback_queue;
+
+
+
+// typedef callback_function
 
 } // namespace gr

--- a/blocklib/common/include/gnuradio/blocklib/sync_block.hpp
+++ b/blocklib/common/include/gnuradio/blocklib/sync_block.hpp
@@ -1,9 +1,10 @@
 #ifndef INCLUDED_SYNC_BLOCK_HPP
 #define INCLUDED_SYNC_BLOCK_HPP
 
-#include <gnuradio/blocklib/block.hpp>
 #include <algorithm>
 #include <limits>
+#include <gnuradio/blocklib/block.hpp>
+
 
 namespace gr {
 /**

--- a/runtime/include/gnuradio/scheduler.hpp
+++ b/runtime/include/gnuradio/scheduler.hpp
@@ -1,18 +1,20 @@
 #pragma once
 
-#include <gnuradio/blocklib/callback.hpp>
-#include <gnuradio/flat_graph.hpp>
 #include <functional>
 #include <memory>
 #include <queue>
+
+#include <gnuradio/blocklib/callback.hpp>
+#include <gnuradio/flat_graph.hpp>
+
 namespace gr {
 class scheduler : public std::enable_shared_from_this<scheduler>
 {
 
-
 public:
     param_action_queue param_change_queue;
     param_action_queue param_query_queue;
+    block_callback_queue callback_queue;
 
     scheduler(){};
     virtual ~scheduler();
@@ -26,22 +28,24 @@ public:
                                          param_action_base param_action,
                                          param_action_complete_fcn cb_when_complete)
     {
-        param_query_queue.emplace(param_action_base_with_callback{block_alias, param_action, cb_when_complete});
-
+        param_query_queue.emplace(param_action_base_with_callback{
+            block_alias, param_action, cb_when_complete });
     }
 
     virtual void request_parameter_change(const std::string& block_alias,
                                           param_action_base param_action,
                                           param_action_complete_fcn cb_when_complete)
     {
-        param_change_queue.emplace(param_action_base_with_callback{block_alias, param_action, cb_when_complete});
-
+        param_change_queue.emplace(param_action_base_with_callback{
+            block_alias, param_action, cb_when_complete });
     }
 
     virtual void request_callback(const std::string& block_alias,
-                                  callback_base callback,
-                                  std::function<void(callback_base)> fn)
+                                  const callback_args& args,
+                                  block_callback_complete_fcn cb_when_complete)
     {
+        callback_queue.emplace(callback_args_with_callback{
+            block_alias, args, cb_when_complete } );
     }
 
     // std::queue<std::tuple<std::string, param_action_base>> param_action_queue()

--- a/schedulers/simplestream/include/gnuradio/schedulers/simplestream/scheduler_simplestream.hpp
+++ b/schedulers/simplestream/include/gnuradio/schedulers/simplestream/scheduler_simplestream.hpp
@@ -125,7 +125,23 @@ private:
                 // handle parameter queries
 
                 // handle general callbacks
+                while (!top->callback_queue.empty()) {
+                    auto item = top->callback_queue.front();
+                    if (item.block_id == b->alias()) {
+                        auto cbs = item.cb_struct;
+                        auto ret = b->callbacks()[cbs.callback_name](cbs.args);
 
+                        cbs.return_val = ret;
+                        if (item.cb_fcn != nullptr)
+                            item.cb_fcn(cbs);
+
+                        top->callback_queue.pop();
+                    } else {
+                        // no parameter changes for this block
+                        go_on_ahead = true;
+                        break;
+                    }
+                }
 
                 std::vector<block_work_input> work_input;   //(num_input_ports);
                 std::vector<block_work_output> work_output; //(num_output_ports);

--- a/schedulers/simplestream/test/test_simplestream.cpp
+++ b/schedulers/simplestream/test/test_simplestream.cpp
@@ -45,6 +45,9 @@ int main(int argc, char* argv[])
         std::cout << "query k is " << mult->k() << std::endl;
 
         mult->set_k(k);
+
+        mult->do_a_bunch_of_things(1,2.0,std::vector<gr_complex>{gr_complex(4.0,5.0)});
+
         if (std::chrono::steady_clock::now() - start > std::chrono::seconds(200))
             break;
 


### PR DESCRIPTION
This adds the ability for a block to register callbacks with itself, then the scheduler to receive requests using std::any arguments to call back into those functions.

