### PR TITLE
Add general purpose dictionary to block

### DIFF
--- a/blocklib/common/include/gnuradio/blocklib/block.hpp
+++ b/blocklib/common/include/gnuradio/blocklib/block.hpp
@@ -19,7 +19,7 @@
 #include <gnuradio/blocklib/node.hpp>
 #include <gnuradio/blocklib/parameter.hpp>
 #include <gnuradio/blocklib/callback.hpp>
-
+#include <gnuradio/blocklib/gpdict.hpp>
 
 
 namespace gr {
@@ -52,9 +52,6 @@ enum class work_return_code_t {
 
 class block : public gr::node, public std::enable_shared_from_this<block>
 {
-public:
-    enum vcolor { WHITE, GREY, BLACK };
-    enum io { INPUT, OUTPUT };
 
 private:
     bool d_output_multiple_set = false;
@@ -63,7 +60,6 @@ private:
     std::map<std::string,block_callback_fcn> _callback_function_map;  // callback_function_map["mult0"]["do_something"](x,y,z)
 
 protected:
-    vcolor d_color;
 
     // These are overridden by the derived class
     static const io_signature_capability d_input_signature_capability;
@@ -101,6 +97,8 @@ public:
      */
     block(const std::string& name);
 
+    gpdict attributes;
+
     virtual bool start() { return true; };
     virtual bool stop() { return true; };
 
@@ -126,9 +124,6 @@ public:
         return d_output_signature_capability;
     }
 
-    // TODO: move to a general dict-based property container
-    vcolor color() const { return d_color; }
-    void set_color(vcolor color) { d_color = color; }
 
     /**
      * @brief Abstract method to call signal processing work from a derived block

--- a/blocklib/common/include/gnuradio/blocklib/gpdict.hpp
+++ b/blocklib/common/include/gnuradio/blocklib/gpdict.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <map>
+#include <string>
+
+
+namespace gr {
+/**
+ * @brief General Purpose Dictionary
+ *
+ * The gpdict allows storage of values to attribute to the block by
+ * use by mechanisms unknown to the block itself.  For example, a scheduler may have a
+ * concept of cpu affinity, but that doesn't really matter to the block itself.
+ * Instead of building in specific requirements to the block, allow a generic storage
+ * container to hold such values
+ */
+class gpdict
+{
+    std::map<std::string, int> _int_dict;
+    std::map<std::string, double> _real_dict;
+    std::map<std::string, bool> _bool_dict;
+    std::map<std::string, std::string> _str_dict;
+
+public:
+    void set_int_value(const std::string& key, const int val) { _int_dict[key] = val; }
+    void set_real_value(const std::string& key, const double val)
+    {
+        _real_dict[key] = val;
+    }
+    void set_string_value(const std::string& key, const std::string& val)
+    {
+        _str_dict[key] = val;
+    }
+    void set_bool_value(const std::string& key, const bool val) { _bool_dict[key] = val; }
+
+    int get_int_value(const std::string& key) { return _int_dict[key]; }
+    double get_real_value(const std::string& key) { return _real_dict[key]; }
+    std::string get_string_value(const std::string& key) { return _str_dict[key]; }
+    bool get_bool_value(const std::string& key) { return _bool_dict[key]; }
+};
+
+} // namespace gr

--- a/runtime/include/gnuradio/flat_graph.hpp
+++ b/runtime/include/gnuradio/flat_graph.hpp
@@ -25,6 +25,9 @@ public:
 
 class flat_graph : public graph
 {
+    static constexpr const char* BLOCK_COLOR_KEY = "color";
+    enum vcolor { WHITE, GREY, BLACK };
+    enum io { INPUT, OUTPUT };
 
 public:
     void clear();

--- a/runtime/lib/flat_graph.cpp
+++ b/runtime/lib/flat_graph.cpp
@@ -288,14 +288,14 @@ block_vector_t flat_graph::calc_reachable_blocks(block_sptr block, block_vector_
 
     // Mark all blocks as unvisited
     for (block_viter_t p = blocks.begin(); p != blocks.end(); p++)
-        (*p)->set_color(block::WHITE);
+        (*p)->attributes.set_int_value(BLOCK_COLOR_KEY, WHITE);
 
     // Recursively mark all reachable blocks
     reachable_dfs_visit(block, blocks);
 
     // Collect all the blocks that have been visited
     for (block_viter_t p = blocks.begin(); p != blocks.end(); p++)
-        if ((*p)->color() == block::BLACK)
+        if ((*p)->attributes.get_int_value(BLOCK_COLOR_KEY) == BLACK)
             result.push_back(*p);
 
     return result;
@@ -305,13 +305,13 @@ block_vector_t flat_graph::calc_reachable_blocks(block_sptr block, block_vector_
 void flat_graph::reachable_dfs_visit(block_sptr block, block_vector_t& blocks)
 {
     // Mark the current one as visited
-    block->set_color(block::BLACK);
+    block->attributes.set_int_value(BLOCK_COLOR_KEY, BLACK);
 
     // Recurse into adjacent vertices
     block_vector_t adjacent = calc_adjacent_blocks(block, blocks);
 
     for (block_viter_t p = adjacent.begin(); p != adjacent.end(); p++)
-        if ((*p)->color() == block::WHITE)
+        if ((*p)->attributes.get_int_value(BLOCK_COLOR_KEY) == WHITE)
             reachable_dfs_visit(*p, blocks);
 }
 
@@ -339,10 +339,10 @@ block_vector_t flat_graph::topological_sort(block_vector_t& blocks)
 
     // Start 'em all white
     for (block_viter_t p = tmp.begin(); p != tmp.end(); p++)
-        (*p)->set_color(block::WHITE);
+        (*p)->attributes.set_int_value(BLOCK_COLOR_KEY,WHITE);
 
     for (block_viter_t p = tmp.begin(); p != tmp.end(); p++) {
-        if ((*p)->color() == block::WHITE)
+        if ((*p)->attributes.get_int_value(BLOCK_COLOR_KEY) == WHITE)
             topological_dfs_visit(*p, result);
     }
 
@@ -374,19 +374,19 @@ bool flat_graph::source_p(block_sptr block) { return calc_upstream_edges(block).
 
 void flat_graph::topological_dfs_visit(block_sptr block, block_vector_t& output)
 {
-    block->set_color(block::GREY);
+    block->attributes.set_int_value(BLOCK_COLOR_KEY,GREY);
     block_vector_t blocks(calc_downstream_blocks(block));
 
     for (block_viter_t p = blocks.begin(); p != blocks.end(); p++) {
-        switch ((*p)->color()) {
-        case block::WHITE:
+        switch ((*p)->attributes.get_int_value(BLOCK_COLOR_KEY)) {
+        case WHITE:
             topological_dfs_visit(*p, output);
             break;
 
-        case block::GREY:
+        case GREY:
             throw std::runtime_error("flow graph has loops!");
 
-        case block::BLACK:
+        case BLACK:
             continue;
 
         default:

--- a/schedulers/simplepacket/include/gnuradio/schedulers/simplepacket/scheduler_simplepacket.hpp
+++ b/schedulers/simplepacket/include/gnuradio/schedulers/simplepacket/scheduler_simplepacket.hpp
@@ -12,6 +12,7 @@ namespace schedulers {
 
 class scheduler_simplestream : scheduler
 {
+
 public:
     static const int s_fixed_buf_size = 32768;
     static const int s_min_items_to_process = 1;


### PR DESCRIPTION
Instead of hardcoding in scheduler specific attributes to the block, just give it a publicly accessible general purpose dictionary that can then be used for whatever.  Probably can be made more elegant.