### PR TITLE
Move mechanisms into base block class

### DIFF
--- a/blocklib/blocks/include/gnuradio/blocklib/blocks/CMakeLists.txt
+++ b/blocklib/blocks/include/gnuradio/blocklib/blocks/CMakeLists.txt
@@ -1,4 +1,5 @@
 install(FILES
+  dummy.hpp
   multiply_const_blk.hpp
   throttle.hpp
   vector_source.hpp

--- a/blocklib/blocks/include/gnuradio/blocklib/blocks/dummy.hpp
+++ b/blocklib/blocks/include/gnuradio/blocklib/blocks/dummy.hpp
@@ -18,12 +18,28 @@ public:
 
         ptr->add_param(param<T>::make(dummy<T>::params::id_a, "a", a, &(ptr->_a)));
         ptr->add_param(param<T>::make(dummy<T>::params::id_b, "b", b, &(ptr->_b)));
-        ptr->add_param(param<size_t>::make(dummy<T>::params::id_vlen, "vlen", vlen, &(ptr->_vlen)));
+        ptr->add_param(
+            param<size_t>::make(dummy<T>::params::id_vlen, "vlen", vlen, &(ptr->_vlen)));
+
+        ptr->add_port(port<T>::make("input",
+                                    port_direction_t::INPUT,
+                                    port_type_t::STREAM,
+                                    std::vector<size_t>{ vlen }));
+        ptr->add_port(port<T>::make("out_a",
+                                    port_direction_t::OUTPUT,
+                                    port_type_t::STREAM,
+                                    std::vector<size_t>{ vlen }));
+
+        ptr->add_port(port<T>::make("out_b",
+                                    port_direction_t::OUTPUT,
+                                    port_type_t::STREAM,
+                                    std::vector<size_t>{ vlen }));
 
         return ptr;
     }
+
     dummy() : sync_block("dummy") {}
-    
+
     virtual work_return_code_t work(std::vector<block_work_input>& work_input,
                                     std::vector<block_work_output>& work_output)
     {
@@ -38,6 +54,8 @@ public:
             optr2[i] = _b * iptr[i];
         }
 
+        work_output[0].n_produced = size;
+        work_output[1].n_produced = size;
         return work_return_code_t::WORK_OK;
     }
 
@@ -45,7 +63,6 @@ private:
     T _a, _b;
     size_t _vlen;
 };
-
 
 
 } // namespace blocks

--- a/blocklib/blocks/include/gnuradio/blocklib/blocks/dummy.hpp
+++ b/blocklib/blocks/include/gnuradio/blocklib/blocks/dummy.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <gnuradio/blocklib/sync_block.hpp>
+
+namespace gr {
+namespace blocks {
+
+template <class T>
+class dummy : public sync_block
+{
+public:
+    enum params : uint32_t { id_a, id_b, id_vlen, num_params };
+
+    typedef std::shared_ptr<dummy> sptr;
+    static sptr make(T a, T b, size_t vlen = 1)
+    {
+        auto ptr = std::make_shared<dummy>(dummy());
+
+        ptr->add_param(param<T>::make(dummy<T>::params::id_a, "a", a, &(ptr->_a)));
+        ptr->add_param(param<T>::make(dummy<T>::params::id_b, "b", b, &(ptr->_b)));
+        ptr->add_param(param<size_t>::make(dummy<T>::params::id_vlen, "vlen", vlen, &(ptr->_vlen)));
+
+        return ptr;
+    }
+    dummy() : sync_block("dummy") {}
+    
+    virtual work_return_code_t work(std::vector<block_work_input>& work_input,
+                                    std::vector<block_work_output>& work_output)
+    {
+        int size = work_output[0].n_items * _vlen;
+
+        auto* iptr = (T*)work_input[0].items;
+        auto* optr1 = (T*)work_output[0].items;
+        auto* optr2 = (T*)work_output[1].items;
+
+        for (auto i = 0; i < size; i++) {
+            optr1[i] = _a * iptr[i];
+            optr2[i] = _b * iptr[i];
+        }
+
+        return work_return_code_t::WORK_OK;
+    }
+
+private:
+    T _a, _b;
+    size_t _vlen;
+};
+
+
+
+} // namespace blocks
+} // namespace gr

--- a/blocklib/blocks/include/gnuradio/blocklib/blocks/multiply_const_blk.hpp
+++ b/blocklib/blocks/include/gnuradio/blocklib/blocks/multiply_const_blk.hpp
@@ -13,7 +13,7 @@ class multiply_const : public sync_block
 private:
 
     T d_k;
-    const size_t d_vlen;
+    size_t d_vlen;
 
     void ports_and_params(size_t);
 
@@ -27,8 +27,8 @@ public:
                                     std::vector<block_work_output>& work_output);
 
 
-    virtual void on_parameter_change(param_action_base param) override;
-    virtual void on_parameter_query(param_action_base& param) override;
+    // virtual void on_parameter_change(param_action_sptr action) override;
+    // virtual void on_parameter_query(param_action_sptr action) override;
     std::any handle_do_a_bunch_of_things(std::vector<std::any> args)
     {
         auto xi = std::any_cast<int>(args[0]);

--- a/blocklib/blocks/include/gnuradio/blocklib/blocks/multiply_const_blk.hpp
+++ b/blocklib/blocks/include/gnuradio/blocklib/blocks/multiply_const_blk.hpp
@@ -9,50 +9,70 @@ namespace blocks {
 template <class T>
 class multiply_const : public sync_block
 {
-
-private:
-
-    T d_k;
-    size_t d_vlen;
-
-    void ports_and_params(size_t);
-
 public:
     enum params : uint32_t { id_k, id_vlen, num_params };
 
-    multiply_const(T k, size_t vlen = 1);
+    typedef std::shared_ptr<multiply_const> sptr;
+    static sptr make(const T k, const size_t vlen = 1)
+    {
+        auto ptr = std::make_shared<multiply_const>(multiply_const<T>());
+
+        ptr->add_port(port<T>::make("input",
+                                    port_direction_t::INPUT,
+                                    port_type_t::STREAM,
+                                    std::vector<size_t>{ vlen }));
+        ptr->add_port(port<T>::make("output",
+                                    port_direction_t::OUTPUT,
+                                    port_type_t::STREAM,
+                                    std::vector<size_t>{ vlen }));
+
+        ptr->add_param(
+            param<T>::make(multiply_const<T>::params::id_k, "k", k, &ptr->d_k));
+
+        // TODO: vlen should be const and unchangeable as a parameter
+        ptr->add_param(param<size_t>::make(
+            multiply_const<T>::params::id_vlen, "vlen", vlen, &ptr->d_vlen));
+
+        ptr->register_callback("do_a_bunch_of_things", [ptr](auto args) {
+            return ptr->handle_do_a_bunch_of_things(args); });
+
+        return ptr;
+
+    }
+    multiply_const();
     // ~multiply_const() {};
 
     virtual work_return_code_t work(std::vector<block_work_input>& work_input,
                                     std::vector<block_work_output>& work_output);
 
 
-    // virtual void on_parameter_change(param_action_sptr action) override;
-    // virtual void on_parameter_query(param_action_sptr action) override;
     std::any handle_do_a_bunch_of_things(std::vector<std::any> args)
     {
-        auto xi = std::any_cast<int>(args[0]);
-        auto yi = std::any_cast<double>(args[1]);
-        auto zi = std::any_cast<std::vector<gr_complex>>(args[2]);
+            auto xi = std::any_cast<int>(args[0]);
+            auto yi = std::any_cast<double>(args[1]);
+            auto zi = std::any_cast<std::vector<gr_complex>>(args[2]);
 
-        return std::make_any<double>(xi*yi);
+            return std::make_any<double>(xi * yi);
     }
 
-    // These methods should be automatically generated
+    // These methods should be automatically generated or macros
     // setters/getters/callback wrappers
     double do_a_bunch_of_things(const int x, const double y, const std::vector<gr_complex>& z);
-    void set_k(T k);
-    T k();
+    void set_k(T k) {return request_parameter_change<T>(params::id_k, k);}
+    T k() { return request_parameter_query<T>(params::id_k); }
 
+private:
 
+    T d_k;
+    size_t d_vlen;
 
-};
+    };
 
-typedef multiply_const<std::int16_t> multiply_const_ss;
-typedef multiply_const<std::int32_t> multiply_const_ii;
-typedef multiply_const<float> multiply_const_ff;
-typedef multiply_const<gr_complex> multiply_const_cc;
+    typedef multiply_const<std::int16_t> multiply_const_ss;
+    typedef multiply_const<std::int32_t> multiply_const_ii;
+    typedef multiply_const<float> multiply_const_ff;
+    typedef multiply_const<gr_complex> multiply_const_cc;
 
 } // namespace blocks
-} // namespace gr
+} // namespace blocks
 #endif

--- a/blocklib/blocks/include/gnuradio/blocklib/blocks/throttle.hpp
+++ b/blocklib/blocks/include/gnuradio/blocklib/blocks/throttle.hpp
@@ -33,19 +33,26 @@ namespace blocks {
  */
 class throttle : virtual public sync_block
 {
-private:
-    std::chrono::time_point<std::chrono::steady_clock> d_start;
-    const size_t d_itemsize;
-    uint64_t d_total_samples;
-    double d_sample_rate;
-    std::chrono::duration<double> d_sample_period;
-    const bool d_ignore_tags;
-
 public:
     typedef std::shared_ptr<throttle> sptr;
 
+    static sptr make(size_t itemsize, double samples_per_sec, bool ignore_tags = true)
+    {
+        auto ptr = std::make_shared<throttle>(throttle(itemsize, samples_per_sec, ignore_tags));
+
+        // TODO: make the throttle "don't care" type (size only)
+        ptr->add_port(port<uint8_t>::make(
+            "input", port_direction_t::INPUT, port_type_t::STREAM, std::vector<size_t>{ 1 }));
+        ptr->add_port(port<uint8_t>::make("output",
+                                port_direction_t::OUTPUT,
+                                port_type_t::STREAM,
+                                std::vector<size_t>{ 1 }));
+
+        return ptr;
+    }
+
     throttle(size_t itemsize, double samples_per_sec, bool ignore_tags = true);
-    ~throttle();
+    // ~throttle();
 
     bool start();
     virtual work_return_code_t work(std::vector<block_work_input>& work_input,
@@ -56,6 +63,15 @@ public:
 
     //! Get the sample rate in samples per second.
     double sample_rate() const;
+
+private:
+    std::chrono::time_point<std::chrono::steady_clock> d_start;
+    const size_t d_itemsize;
+    uint64_t d_total_samples;
+    double d_sample_rate;
+    std::chrono::duration<double> d_sample_period;
+    const bool d_ignore_tags;
+
 };
 
 } /* namespace blocks */

--- a/blocklib/blocks/include/gnuradio/blocklib/blocks/vector_sink.hpp
+++ b/blocklib/blocks/include/gnuradio/blocklib/blocks/vector_sink.hpp
@@ -26,7 +26,7 @@ private:
     std::vector<T> d_data;
     std::vector<tag_t> d_tags;
     mutable std::mutex d_data_mutex; // protects internal data access.
-    unsigned int d_vlen;
+    size_t d_vlen;
 
 public:
     enum params : uint32_t { num_params };

--- a/blocklib/blocks/include/gnuradio/blocklib/blocks/vector_sink.hpp
+++ b/blocklib/blocks/include/gnuradio/blocklib/blocks/vector_sink.hpp
@@ -22,27 +22,67 @@ namespace blocks {
 template <class T>
 class vector_sink : virtual public sync_block
 {
-private:
-    std::vector<T> d_data;
-    std::vector<tag_t> d_tags;
-    mutable std::mutex d_data_mutex; // protects internal data access.
-    size_t d_vlen;
 
 public:
-    enum params : uint32_t { num_params };
+    enum params : uint32_t { id_vlen, id_data, id_tags, num_params };
+    typedef std::shared_ptr<vector_sink> sptr;
 
-    vector_sink(unsigned int vlen = 1, const int reserve_items = 1024);
+    static sptr make(const size_t vlen = 1, const size_t reserve_items = 1024)
+    {
+        auto ptr = std::make_shared<vector_sink>(vector_sink(vlen, reserve_items));
+
+        ptr->add_port(port<T>::make("input",
+                                    port_direction_t::INPUT,
+                                    port_type_t::STREAM,
+                                    std::vector<size_t>{ vlen }));
+
+        ptr->add_param(param<size_t>::make(
+            vector_sink::params::id_vlen, "vlen", vlen, &(ptr->_vlen)));
+        ptr->add_param(param<std::vector<T>>::make(
+            vector_sink::params::id_data, "data", std::vector<T>{}, &(ptr->_data)));
+        ptr->add_param(param<std::vector<tag_t>>::make(
+            vector_sink::params::id_tags, "tags", std::vector<tag_t>{}, &(ptr->_tags)));
+
+        return ptr;
+    }
+
+    vector_sink(const size_t vlen = 1, const size_t reserve_items = 1024);
     // ~vector_sink() {};
-
-    //! Clear the data and tags containers.
-    void reset();
-    const std::vector<T> data();
-    const std::vector<tag_t> tags();
 
     work_return_code_t work(std::vector<block_work_input>& work_input,
                             std::vector<block_work_output>& work_output);
-};
 
+    std::any handle_reset(std::vector<std::any> args)
+    {
+        _tags.clear();
+        _data.clear();
+
+        return std::any();
+    }
+
+    //! Clear the data and tags containers.
+    void reset();
+    std::vector<T> data()
+    {
+        return request_parameter_query<std::vector<T>>(params::id_data);
+    }
+
+    // since _data is changed inside work(), we must catch and update the current value
+    virtual void on_parameter_query(param_action_sptr action)
+    {
+        if (action->id() == id_data) {
+            auto param = parameters.get(action->id());
+            action->set_any_value(std::any_cast<std::vector<T>>(_data));
+        } else {
+            block::on_parameter_query(action);
+        }
+    }
+
+private:
+    std::vector<T> _data;
+    std::vector<tag_t> _tags;
+    size_t _vlen;
+};
 typedef vector_sink<std::uint8_t> vector_sink_b;
 typedef vector_sink<std::int16_t> vector_sink_s;
 typedef vector_sink<std::int32_t> vector_sink_i;

--- a/blocklib/blocks/include/gnuradio/blocklib/blocks/vector_source.hpp
+++ b/blocklib/blocks/include/gnuradio/blocklib/blocks/vector_source.hpp
@@ -22,7 +22,7 @@ private:
     std::vector<tag_t> d_tags;
 
 public:
-    enum params : uint32_t { data, repeat, vlen, num_params };
+    enum params : uint32_t { id_data, id_repeat, id_vlen, num_params };
     vector_source(const std::vector<T>& data,
                   bool repeat = false,
                   unsigned int vlen = 1,

--- a/blocklib/blocks/include/gnuradio/blocklib/blocks/vector_source.hpp
+++ b/blocklib/blocks/include/gnuradio/blocklib/blocks/vector_source.hpp
@@ -9,24 +9,41 @@ namespace blocks {
 template <class T>
 class vector_source : virtual public sync_block
 {
-private:
-    // static const io_signature_capability d_input_signature_capability =
-    // io_signature_capability(0, 0); static const io_signature_capability
-    // d_output_signature_capability = io_signature_capability(1, -1);
-
-    std::vector<T> d_data;
-    bool d_repeat;
-    unsigned int d_offset;
-    unsigned int d_vlen;
-    bool d_settags;
-    std::vector<tag_t> d_tags;
 
 public:
-    enum params : uint32_t { id_data, id_repeat, id_vlen, num_params };
+    enum params : uint32_t { id_data, id_repeat, id_vlen, id_tags, num_params };
+
+    typedef std::shared_ptr<vector_source> sptr;
+    static sptr make(const std::vector<T>& data,
+                     bool repeat = false,
+                     unsigned int vlen = 1,
+                     const std::vector<tag_t>& tags = std::vector<tag_t>())
+    {
+
+        auto ptr = std::make_shared<vector_source>(vector_source(data, repeat, vlen, tags));
+
+
+        ptr->add_port(port<T>::make("output",
+                                    port_direction_t::OUTPUT,
+                                    port_type_t::STREAM,
+                                    std::vector<size_t>{ vlen }));
+
+        ptr->add_param(
+            param<std::vector<T>>::make(vector_source::params::id_data, "data", data, &ptr->_data));
+        ptr->add_param(
+            param<bool>::make(vector_source::params::id_repeat, "repeat", repeat, &ptr->_repeat));
+        ptr->add_param(
+            param<size_t>::make(vector_source::params::id_vlen, "vlen", vlen, &ptr->_vlen));
+        ptr->add_param(
+            param<std::vector<tag_t>>::make(vector_source::params::id_tags, "tags", tags, &ptr->_tags));
+
+        return ptr;
+    }
+
     vector_source(const std::vector<T>& data,
-                  bool repeat = false,
-                  unsigned int vlen = 1,
-                  const std::vector<tag_t>& tags = std::vector<tag_t>());
+                                bool repeat,
+                                unsigned int vlen,
+                                const std::vector<tag_t>& tags);
     // ~vector_source() {};
 
     virtual work_return_code_t work(std::vector<block_work_input>& work_input,
@@ -36,6 +53,14 @@ public:
     void set_data(const std::vector<T>& data,
                   const std::vector<tag_t>& tags = std::vector<tag_t>());
     void set_repeat(bool repeat);
+
+private:
+    std::vector<T> _data;
+    bool _repeat;
+    unsigned int _offset;
+    size_t _vlen;
+    bool _settags;
+    std::vector<tag_t> _tags;
 };
 
 typedef vector_source<std::uint8_t> vector_source_b;

--- a/blocklib/blocks/lib/CMakeLists.txt
+++ b/blocklib/blocks/lib/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(gnuradio-blocklib-blocks SHARED
+  dummy.cpp
   multiply_const_blk.cpp
   throttle.cpp
   vector_sink.cpp

--- a/blocklib/blocks/lib/dummy.cpp
+++ b/blocklib/blocks/lib/dummy.cpp
@@ -1,0 +1,11 @@
+#include <gnuradio/blocklib/blocks/dummy.hpp>
+
+namespace gr {
+namespace blocks {
+
+template class dummy<std::int16_t>;
+template class dummy<float>;
+template class dummy<gr_complex>;
+
+}
+} // namespace gr

--- a/blocklib/blocks/lib/multiply_const_blk.cpp
+++ b/blocklib/blocks/lib/multiply_const_blk.cpp
@@ -95,6 +95,7 @@ template <class T>
 work_return_code_t multiply_const<T>::work(std::vector<block_work_input>& work_input,
                                            std::vector<block_work_output>& work_output)
 {
+    // Pre-generate these from modtool, for example
     T* iptr = (T*)work_input[0].items;
     T* optr = (T*)work_output[0].items;
 
@@ -164,6 +165,7 @@ T multiply_const<T>::k()
 
     // call back to the scheduler if ptr is not null
     if (p_scheduler) {
+        // not thread safe - fix with condition variable
         bool gotit = false;
         T newval;
         auto lam = [&](auto a) {
@@ -174,6 +176,7 @@ T multiply_const<T>::k()
         p_scheduler->request_parameter_query(
             alias(), param_action<T>(params::id_k, 0, 0), lam);
 
+        // replace with condition variable
         while(!gotit)
         {
             std::this_thread::sleep_for(std::chrono::milliseconds(1));

--- a/blocklib/blocks/lib/multiply_const_blk.cpp
+++ b/blocklib/blocks/lib/multiply_const_blk.cpp
@@ -9,8 +9,8 @@
 #include <condition_variable>
 #include <volk/volk.h>
 #include <chrono>
-#include <thread>
 #include <mutex>
+#include <thread>
 
 namespace gr {
 namespace blocks {
@@ -27,11 +27,11 @@ void multiply_const<T>::ports_and_params(size_t vlen)
                            port_type_t::STREAM,
                            std::vector<size_t>{ vlen }));
 
-    add_param(param<T>::make(
-        multiply_const<T>::params::id_k, "k", 1.0, &d_k));
+    add_param(param<T>::make(multiply_const<T>::params::id_k, "k", 1.0, &d_k));
 
-    add_param(param<size_t>::make(
-        multiply_const<T>::params::id_vlen, "vlen", vlen, &d_vlen));
+    // TODO: vlen should be const and unchangeable as a parameter
+    add_param(
+        param<size_t>::make(multiply_const<T>::params::id_vlen, "vlen", vlen, &d_vlen));
 
     register_callback("do_a_bunch_of_things", [this](auto args) {
         return this->handle_do_a_bunch_of_things(args);
@@ -125,37 +125,23 @@ work_return_code_t multiply_const<T>::work(std::vector<block_work_input>& work_i
     return work_return_code_t::WORK_OK;
 }
 
-// template <class T>
-// void multiply_const<T>::on_parameter_change(param_action_sptr param)
-// {
-//     if (param->id() == multiply_const<T>::params::id_k) {
-//         d_k = static_cast<param_action<T>>(param).new_value();
-//     } else if (param->id() == multiply_const<T>::params::id_vlen) {
-//         // cannot be changed
-//     }
-// }
-
-// template <class T>
-// void multiply_const<T>::on_parameter_query(param_action_base& param)
-// {
-//     if (param.id() == multiply_const<T>::params::id_k) {
-//         param.set_any_value(std::make_any<T>(d_k));
-//     } else if (param.id() == multiply_const<T>::params::id_vlen) {
-//         param.set_any_value(std::make_any<T>(d_vlen));
-//     }
-// }
-
 template <class T>
 void multiply_const<T>::set_k(T k)
 {
     // call back to the scheduler if ptr is not null
     if (p_scheduler) {
+        std::condition_variable cv;
+        std::mutex m;
+        auto lam = [&](param_action_sptr a) {
+            std::unique_lock<std::mutex> lk(m);
+            cv.notify_one();
+        };
         p_scheduler->request_parameter_change(
-            alias(), param_action<T>::make(params::id_k, k, 0), [&](param_action_sptr a) {
-                std::cout << "k was changed to "
-                          << std::static_pointer_cast<param_action<T>>(a)->new_value()
-                          << std::endl;
-            });
+            alias(), param_action<T>::make(params::id_k, k, 0), lam);
+
+        // block until confirmation that parameter has been set
+        std::unique_lock<std::mutex> lk(m);
+        cv.wait(lk);
 
     }
     // else go ahead and update parameter value
@@ -169,32 +155,21 @@ T multiply_const<T>::k()
 {
     // call back to the scheduler if ptr is not null
     if (p_scheduler) {
-        // not thread safe - fix with condition variable
-        // std::condition_variable cv;
-        // std::mutex m;
-        bool ready = false;
+        std::condition_variable cv;
+        std::mutex m;
         T newval;
         auto lam = [&](param_action_sptr a) {
-            // std::unique_lock<std::mutex> lk(m);
-            // cv.wait(lk);
+            std::unique_lock<std::mutex> lk(m);
             newval = std::static_pointer_cast<param_action<T>>(a)->new_value();
-            // lk.unlock();
-            // cv.notify_one();
-            ready = true;
+            cv.notify_one();
         };
-
-        // std::unique_lock<std::mutex> lk(m);
-        // cv.wait(lk);
 
         p_scheduler->request_parameter_query(
             alias(), param_action<T>::make(params::id_k, 0, 0), lam);
 
-        // replace with condition variable
-        while (!ready) {
-            std::this_thread::sleep_for(std::chrono::milliseconds(1));
-        }
-
-            return newval;
+        std::unique_lock<std::mutex> lk(m);
+        cv.wait(lk);
+        return newval;
     }
     // else go ahead and return parameter value
     else {
@@ -202,6 +177,8 @@ T multiply_const<T>::k()
     }
 }
 
+// A notional generic callback used as an example.  Should not actually be part of the
+// multiply_const block
 template <class T>
 double multiply_const<T>::do_a_bunch_of_things(const int x,
                                                const double y,

--- a/blocklib/blocks/lib/throttle.cpp
+++ b/blocklib/blocks/lib/throttle.cpp
@@ -25,18 +25,12 @@ namespace blocks {
 throttle::throttle(size_t itemsize, double samples_per_second, bool ignore_tags)
     : sync_block("throttle"), d_itemsize(itemsize), d_ignore_tags(ignore_tags)
 {
-    // TODO: make the throttle "don't care" type (size only)
-    add_port(port<float>::make(
-        "input", port_direction_t::INPUT, port_type_t::STREAM, std::vector<size_t>{ 1 }));
-    add_port(port<float>::make("output",
-                               port_direction_t::OUTPUT,
-                               port_type_t::STREAM,
-                               std::vector<size_t>{ 1 }));
+
 
     set_sample_rate(samples_per_second);
 }
 
-throttle::~throttle() {}
+// throttle::~throttle() {}
 
 bool throttle::start()
 {

--- a/blocklib/blocks/lib/vector_source.cpp
+++ b/blocklib/blocks/lib/vector_source.cpp
@@ -36,8 +36,8 @@ vector_source<T>::vector_source(const std::vector<T>& data,
                            std::vector<size_t>{ vlen }));
 
     add_param(
-        param<std::vector<T>>(vector_source::params::data, "data", std::vector<T>()));
-    add_param(param<bool>(vector_source::params::repeat, "repeat", false));
+        param<std::vector<T>>::make(vector_source::params::id_data, "data", data, &d_data, std::vector<size_t>(vlen)));
+    add_param(param<bool>::make(vector_source::params::id_repeat, "repeat", repeat, &d_repeat));
 
     if (tags.empty()) {
         d_settags = 0;

--- a/blocklib/common/include/gnuradio/blocklib/block.hpp
+++ b/blocklib/common/include/gnuradio/blocklib/block.hpp
@@ -97,6 +97,9 @@ public:
      */
     block(const std::string& name);
 
+    // just maintain metadata in scheduler mapped to the blocks
+    
+
     gpdict attributes;
 
     virtual bool start() { return true; };

--- a/blocklib/common/include/gnuradio/blocklib/block.hpp
+++ b/blocklib/common/include/gnuradio/blocklib/block.hpp
@@ -78,7 +78,7 @@ protected:
 
     parameter_config parameters;
 
-    void add_param(param_base p) { parameters.add(p); }
+    void add_param(param_sptr p) { parameters.add(p); }
 
     std::shared_ptr<scheduler> p_scheduler = nullptr;
 
@@ -100,7 +100,7 @@ public:
     // just maintain metadata in scheduler mapped to the blocks
     
 
-    gpdict attributes;
+    gpdict attributes; // this is a hack for storing metadata.  Needs to go.
 
     virtual bool start() { return true; };
     virtual bool stop() { return true; };
@@ -161,14 +161,16 @@ public:
      * @param params
      */
 
-    virtual void on_parameter_change(param_action_base param)
+    virtual void on_parameter_change(param_action_sptr action)
     {
-        throw std::runtime_error("parameter changes not defined for this block");
+        auto param = parameters.get(action->id());
+        param->set_value(action->any_value());
     }
 
-    virtual void on_parameter_query(param_action_base& param)
+    virtual void on_parameter_query(param_action_sptr action)
     {
-        throw std::runtime_error("parameter queries not defined for this block");
+        auto param = parameters.get(action->id());
+        action->set_any_value(param->any_value());
     }
 
     std::map<std::string,block_callback_fcn> callbacks() {return _callback_function_map;}

--- a/blocklib/common/include/gnuradio/blocklib/block.hpp
+++ b/blocklib/common/include/gnuradio/blocklib/block.hpp
@@ -163,11 +163,6 @@ public:
         throw std::runtime_error("parameter changes not defined for this block");
     }
 
-    virtual void parameter_change_complete(param_action_base param)
-    {
-        std::cout << "param_action_complete" << std::endl;
-    }
-
     virtual void on_parameter_query(param_action_base& param)
     {
         throw std::runtime_error("parameter queries not defined for this block");

--- a/blocklib/common/include/gnuradio/blocklib/block.hpp
+++ b/blocklib/common/include/gnuradio/blocklib/block.hpp
@@ -12,7 +12,8 @@
 #include <string>
 #include <vector>
 #include <memory>
-		
+#include <condition_variable>
+
 #include <gnuradio/blocklib/block_callbacks.hpp>
 #include <gnuradio/blocklib/block_work_io.hpp>
 #include <gnuradio/blocklib/io_signature.hpp>
@@ -20,7 +21,6 @@
 #include <gnuradio/blocklib/parameter.hpp>
 #include <gnuradio/blocklib/callback.hpp>
 #include <gnuradio/blocklib/gpdict.hpp>
-
 
 namespace gr {
 
@@ -177,6 +177,11 @@ public:
 
 
     void set_scheduler(std::shared_ptr<scheduler> sched) { p_scheduler = sched; }
+
+    template <class T>
+    T request_parameter_query(int param_id);
+    template <class T>
+    void request_parameter_change(int param_id, T new_value);
 };
 
 typedef block::sptr block_sptr;

--- a/blocklib/common/include/gnuradio/blocklib/parameter.hpp
+++ b/blocklib/common/include/gnuradio/blocklib/parameter.hpp
@@ -110,6 +110,7 @@ public:
           _default_value(default_value),
           _value_ptr(value_ptr)
     {
+        set_value(default_value);
     }
 
     param(param_base& b) : param_base(b) { _value = std::any_cast<T>(b.any_value()); }
@@ -165,10 +166,22 @@ protected:
 public:
     typedef std::shared_ptr<param_action<T>> sptr;
 
+    static sptr make(uint32_t id)
+    {
+        return std::make_shared<param_action<T>>(param_action<T>(id));
+    }
+
     static sptr make(uint32_t id, T new_value, uint64_t at_sample)
     {
         return std::make_shared<param_action<T>>(param_action<T>(id, new_value, at_sample));
     }
+
+    // Constructor where the current value is "don't care"
+    param_action(uint32_t id)
+        : param_action_base(id, std::any(), 0)
+    {
+    }
+
     param_action(uint32_t id, T new_value, uint64_t at_sample)
         : param_action_base(id, std::make_any<T>(new_value), at_sample),
           _new_value(new_value)

--- a/blocklib/common/include/gnuradio/blocklib/parameter.hpp
+++ b/blocklib/common/include/gnuradio/blocklib/parameter.hpp
@@ -71,20 +71,6 @@ public:
     const std::any any_value() { return _any_value; }
     const param_type_t type() { return _type; }
 
-
-    // // Ok, here goes ... all the possible parameter value types
-    // virtual void set_value(float val) = 0;
-    // virtual void set_value(double val) = 0;
-    // virtual void set_value(gr_complex val) = 0;
-    // virtual void set_value(int8_t val) = 0;
-    // virtual void set_value(int16_t val) = 0;
-    // virtual void set_value(int32_t val) = 0;
-    // virtual void set_value(int64_t val) = 0;
-    // virtual void set_value(uint8_t val) = 0;
-    // virtual void set_value(uint16_t val) = 0;
-    // virtual void set_value(uint32_t val) = 0;
-    // virtual void set_value(uint64_t val) = 0;
-
     virtual void set_value(const std::any& val) = 0;
 
 
@@ -142,7 +128,7 @@ public:
     T value() { return *_value_ptr; };
 
 protected:
-    T* _value_ptr;
+    T* _value_ptr; // TODO: use smart pointer
     T _default_value;
     T _value;
     value_check _range;

--- a/blocklib/common/include/gnuradio/blocklib/port.hpp
+++ b/blocklib/common/include/gnuradio/blocklib/port.hpp
@@ -73,6 +73,9 @@ public:
 
 typedef port_base::sptr port_sptr;
 
+
+// TODO: how to handle "don't care "
+// Could be problematic due to total permutations of types implemented [TBD]
 template <class T>
 class port : public port_base
 {

--- a/blocklib/common/lib/CMakeLists.txt
+++ b/blocklib/common/lib/CMakeLists.txt
@@ -14,7 +14,7 @@ target_include_directories(gnuradio-blocklib-common
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
   PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}
-  # ${PROJECT_SOURCE_DIR}/runtime/include 
+  ${PROJECT_SOURCE_DIR}/runtime/include 
   )
 
 message(STATUS ${INTERFACE_INCLUDE_DIRECTORIES})

--- a/blocklib/common/lib/block.cpp
+++ b/blocklib/common/lib/block.cpp
@@ -1,8 +1,116 @@
 
 #include <gnuradio/blocklib/block.hpp>
 
+// FIXME - would like to avoid dependence on scheduler
+// conditionally include this
+#include <gnuradio/scheduler.hpp>
+
 namespace gr {
 // block::~block() {}
-block::block(const std::string& name) : node(name) {}
+block::block(const std::string& name) : node(name) {} 
+
+
+template <class T>
+void block::request_parameter_change(int param_id, T new_value)
+{
+    // call back to the scheduler if ptr is not null
+    if (p_scheduler) {
+        std::condition_variable cv;
+        std::mutex m;
+        auto lam = [&](param_action_sptr a) {
+            std::unique_lock<std::mutex> lk(m);
+            cv.notify_one();
+        };
+        p_scheduler->request_parameter_change(
+            alias(), param_action<T>::make(param_id, new_value, 0), lam);
+
+        // block until confirmation that parameter has been set
+        std::unique_lock<std::mutex> lk(m);
+        cv.wait(lk);
+    }
+    // else go ahead and update parameter value
+    else {
+        on_parameter_change(param_action<T>::make(param_id, new_value, 0));
+    }
+}
+
+template <class T>
+T block::request_parameter_query(int param_id)
+{
+    // call back to the scheduler if ptr is not null
+    if (p_scheduler) {
+        std::condition_variable cv;
+        std::mutex m;
+        T newval;
+        auto lam = [&](param_action_sptr a) {
+            std::unique_lock<std::mutex> lk(m);
+            newval = std::static_pointer_cast<param_action<T>>(a)->new_value();
+            cv.notify_one();
+        };
+
+        p_scheduler->request_parameter_query(
+            alias(), param_action<T>::make(param_id), lam);
+
+        std::unique_lock<std::mutex> lk(m);
+        cv.wait(lk);
+        return newval;
+    }
+    // else go ahead and return parameter value
+    else {
+        auto action = param_action<T>::make(param_id);
+        on_parameter_query(action);
+        return action->new_value();
+    }
+}
+
+// Acceptable parameter query types (has to be a better way to do this)
+template float block::request_parameter_query<float>(int);
+template double block::request_parameter_query<double>(int);
+template gr_complex block::request_parameter_query<gr_complex>(int);
+template int8_t block::request_parameter_query<int8_t>(int);
+template int16_t block::request_parameter_query<int16_t>(int);
+template int32_t block::request_parameter_query<int32_t>(int);
+template int64_t block::request_parameter_query<int64_t>(int);
+template uint8_t block::request_parameter_query<uint8_t>(int);
+template uint16_t block::request_parameter_query<uint16_t>(int);
+template uint32_t block::request_parameter_query<uint32_t>(int);
+template uint64_t block::request_parameter_query<uint64_t>(int);
+
+template std::vector<float> block::request_parameter_query<std::vector<float>>(int);
+template std::vector<double> block::request_parameter_query<std::vector<double>>(int);
+template std::vector<gr_complex> block::request_parameter_query<std::vector<gr_complex>>(int);
+template std::vector<int8_t> block::request_parameter_query<std::vector<int8_t>>(int);
+template std::vector<int16_t> block::request_parameter_query<std::vector<int16_t>>(int);
+template std::vector<int32_t> block::request_parameter_query<std::vector<int32_t>>(int);
+template std::vector<int64_t> block::request_parameter_query<std::vector<int64_t>>(int);
+template std::vector<uint8_t> block::request_parameter_query<std::vector<uint8_t>>(int);
+template std::vector<uint16_t> block::request_parameter_query<std::vector<uint16_t>>(int);
+template std::vector<uint32_t> block::request_parameter_query<std::vector<uint32_t>>(int);
+template std::vector<uint64_t> block::request_parameter_query<std::vector<uint64_t>>(int);
+
+template void block::request_parameter_change<float>(int,float);
+template void block::request_parameter_change<double>(int,double);
+template void block::request_parameter_change<gr_complex>(int,gr_complex);
+template void block::request_parameter_change<int8_t>(int,int8_t);
+template void block::request_parameter_change<int16_t>(int,int16_t);
+template void block::request_parameter_change<int32_t>(int,int32_t);
+template void block::request_parameter_change<int64_t>(int,int64_t);
+template void block::request_parameter_change<uint8_t>(int,uint8_t);
+template void block::request_parameter_change<uint16_t>(int,uint16_t);
+template void block::request_parameter_change<uint32_t>(int,uint32_t);
+template void block::request_parameter_change<uint64_t>(int,uint64_t);
+
+template void block::request_parameter_change<std::vector<float>>(int,std::vector<float>);
+template void block::request_parameter_change<std::vector<double>>(int,std::vector<double>);
+template void block::request_parameter_change<std::vector<gr_complex>>(int,std::vector<gr_complex>);
+template void block::request_parameter_change<std::vector<int8_t>>(int,std::vector<int8_t>);
+template void block::request_parameter_change<std::vector<int16_t>>(int,std::vector<int16_t>);
+template void block::request_parameter_change<std::vector<int32_t>>(int,std::vector<int32_t>);
+template void block::request_parameter_change<std::vector<int64_t>>(int,std::vector<int64_t>);
+template void block::request_parameter_change<std::vector<uint8_t>>(int,std::vector<uint8_t>);
+template void block::request_parameter_change<std::vector<uint16_t>>(int,std::vector<uint16_t>);
+template void block::request_parameter_change<std::vector<uint32_t>>(int,std::vector<uint32_t>);
+template void block::request_parameter_change<std::vector<uint64_t>>(int,std::vector<uint64_t>);
+
 
 } // namespace gr

--- a/blocklib/common/lib/parameter.cpp
+++ b/blocklib/common/lib/parameter.cpp
@@ -1,0 +1,43 @@
+#include <gnuradio/blocklib/parameter.hpp>
+
+namespace gr {
+
+
+    // virtual void set_value(float val) = 0;
+    // virtual void set_value(double val) = 0;
+    // virtual void set_value(gr_complex val) = 0;
+    // virtual void set_value(int8_t val) = 0;
+    // virtual void set_value(int16_t val) = 0;
+    // virtual void set_value(int32_t val) = 0;
+    // virtual void set_value(int64_t val) = 0;
+    // virtual void set_value(uint8_t val) = 0;
+    // virtual void set_value(uint16_t val) = 0;
+    // virtual void set_value(uint32_t val) = 0;
+    // virtual void set_value(uint64_t val) = 0;
+
+// template class parameter_base<float>;
+// template class parameter_base<double>;
+// template class parameter_base<gr_complex>;
+// template class parameter_base<std::int8_t>;
+// template class parameter_base<std::int16_t>;
+// template class parameter_base<std::int32_t>;
+// template class parameter_base<std::int64_t>;
+// template class parameter_base<std::uint8_t>;
+// template class parameter_base<std::uint16_t>;
+// template class parameter_base<std::uint32_t>;
+// template class parameter_base<std::uint64_t>;
+
+
+template class parameter<float>;
+template class parameter<double>;
+template class parameter<gr_complex>;
+template class parameter<std::int8_t>;
+template class parameter<std::int16_t>;
+template class parameter<std::int32_t>;
+template class parameter<std::int64_t>;
+template class parameter<std::uint8_t>;
+template class parameter<std::uint16_t>;
+template class parameter<std::uint32_t>;
+template class parameter<std::uint64_t>;
+
+}

--- a/runtime/include/gnuradio/scheduler.hpp
+++ b/runtime/include/gnuradio/scheduler.hpp
@@ -25,7 +25,7 @@ public:
     virtual void wait() = 0;
 
     virtual void request_parameter_query(const std::string& block_alias,
-                                         param_action_base param_action,
+                                         param_action_sptr param_action,
                                          param_action_complete_fcn cb_when_complete)
     {
         param_query_queue.emplace(param_action_base_with_callback{
@@ -33,7 +33,7 @@ public:
     }
 
     virtual void request_parameter_change(const std::string& block_alias,
-                                          param_action_base param_action,
+                                          param_action_sptr param_action,
                                           param_action_complete_fcn cb_when_complete)
     {
         param_change_queue.emplace(param_action_base_with_callback{

--- a/schedulers/simplestream/test/test_simplestream.cpp
+++ b/schedulers/simplestream/test/test_simplestream.cpp
@@ -13,12 +13,11 @@ using namespace gr;
 
 int main(int argc, char* argv[])
 {
-    std::shared_ptr<blocks::multiply_const_ff> mult(
-        new blocks::multiply_const_ff(100.0)); // create a block that multiplies by 17
+    auto mult = blocks::multiply_const_ff::make(100.0); // create a block that multiplies by 17
     std::shared_ptr<blocks::vector_source_f> src(new blocks::vector_source_f(
         std::vector<float>({ 1.0, 2.0, 3.0, 4.0, 5.0 }), true));
     std::shared_ptr<blocks::throttle> throttle(new blocks::throttle(sizeof(float), 100));
-    std::shared_ptr<blocks::vector_sink_f> snk(new blocks::vector_sink_f());
+    auto snk = blocks::vector_sink_f::make();
     // blocks::vector_sink_f snk();
 
     // mult->on_parameter_change(std::vector<param_action_base>{

--- a/schedulers/simplestream/test/test_simplestream.cpp
+++ b/schedulers/simplestream/test/test_simplestream.cpp
@@ -36,6 +36,9 @@ int main(int argc, char* argv[])
     fg->set_scheduler(sched->base());
 
     fg->validate();
+
+    // what happens when k is set here???  
+
     fg->start();
 
     auto start = std::chrono::steady_clock::now();

--- a/schedulers/simplestream/test/test_simplestream.cpp
+++ b/schedulers/simplestream/test/test_simplestream.cpp
@@ -13,10 +13,11 @@ using namespace gr;
 
 int main(int argc, char* argv[])
 {
-    auto mult = blocks::multiply_const_ff::make(100.0); // create a block that multiplies by 17
-    std::shared_ptr<blocks::vector_source_f> src(new blocks::vector_source_f(
-        std::vector<float>({ 1.0, 2.0, 3.0, 4.0, 5.0 }), true));
-    std::shared_ptr<blocks::throttle> throttle(new blocks::throttle(sizeof(float), 100));
+    auto mult =
+        blocks::multiply_const_ff::make(100.0); // create a block that multiplies by 17
+    auto src = blocks::vector_source_f::make(
+        std::vector<float>{ 1.0, 2.0, 3.0, 4.0, 5.0 }, true);
+    auto throttle = blocks::throttle::make(sizeof(float), 100);
     auto snk = blocks::vector_sink_f::make();
     // blocks::vector_sink_f snk();
 
@@ -36,7 +37,7 @@ int main(int argc, char* argv[])
 
     fg->validate();
 
-    // what happens when k is set here???  
+    // what happens when k is set here???
 
     fg->start();
 
@@ -48,7 +49,8 @@ int main(int argc, char* argv[])
 
         mult->set_k(k);
 
-        mult->do_a_bunch_of_things(1,2.0,std::vector<gr_complex>{gr_complex(4.0,5.0)});
+        mult->do_a_bunch_of_things(
+            1, 2.0, std::vector<gr_complex>{ gr_complex(4.0, 5.0) });
 
         if (std::chrono::steady_clock::now() - start > std::chrono::seconds(200))
             break;


### PR DESCRIPTION
Ongoing process to simplify the block API.  Adds make functions 
Simplify the constructor where applicable by intercepting port and param definitons in the make function