### PR TITLE
sched: single block with multiple outputs

### DIFF
--- a/blocklib/common/lib/block.cpp
+++ b/blocklib/common/lib/block.cpp
@@ -14,7 +14,7 @@ template <class T>
 void block::request_parameter_change(int param_id, T new_value)
 {
     // call back to the scheduler if ptr is not null
-    if (p_scheduler) {
+    if (p_scheduler && d_running) {
         std::condition_variable cv;
         std::mutex m;
         auto lam = [&](param_action_sptr a) {
@@ -38,7 +38,7 @@ template <class T>
 T block::request_parameter_query(int param_id)
 {
     // call back to the scheduler if ptr is not null
-    if (p_scheduler) {
+    if (p_scheduler && d_running) {
         std::condition_variable cv;
         std::mutex m;
         T newval;

--- a/runtime/include/gnuradio/flat_graph.hpp
+++ b/runtime/include/gnuradio/flat_graph.hpp
@@ -59,17 +59,21 @@ public:
         return fg;
     }
 
-    edge find_edge(port_sptr port)
+    std::vector<edge> find_edge(port_sptr port)
     {
+        std::vector<edge> ret;
         for (auto& e : edges()) {
             if (e.src().port() == port)
-                return e;
+                ret.push_back(e);
 
             if (e.dst().port() == port)
-                return e;
+                ret.push_back(e);
         }
 
-        throw std::invalid_argument("edge not found");
+        if (ret.empty())
+            throw std::invalid_argument("edge not found");
+
+        return ret;
     }
 
 protected:

--- a/schedulers/simplestream/include/gnuradio/schedulers/simplestream/simplebuffer.hpp
+++ b/schedulers/simplestream/include/gnuradio/schedulers/simplestream/simplebuffer.hpp
@@ -75,4 +75,9 @@ public:
             _write_index -= _buf_size;
         }
     }
+
+    void copy_items(sptr from, int nitems)
+    {
+        memcpy(write_ptr(), from->write_ptr(), nitems*_item_size);
+    }
 };

--- a/schedulers/simplestream/test/CMakeLists.txt
+++ b/schedulers/simplestream/test/CMakeLists.txt
@@ -2,6 +2,7 @@
 
 add_executable(test_simplestream test_simplestream.cpp)
 add_executable(test_multiple_output test_multiple_output.cpp)
+add_executable(test_one_to_many test_one_to_many.cpp)
 
 target_include_directories(gnuradio-scheduler-simplestream
 PUBLIC
@@ -20,6 +21,13 @@ target_link_libraries(test_simplestream
 )
 
 target_link_libraries(test_multiple_output 
+    gnuradio-blocklib-common
+    gnuradio-blocklib-blocks
+    gnuradio-runtime
+    gnuradio-scheduler-simplestream
+)
+
+target_link_libraries(test_one_to_many 
     gnuradio-blocklib-common
     gnuradio-blocklib-blocks
     gnuradio-runtime

--- a/schedulers/simplestream/test/test_one_to_many.cpp
+++ b/schedulers/simplestream/test/test_one_to_many.cpp
@@ -1,0 +1,43 @@
+#include <chrono>
+#include <iostream>
+#include <thread>
+
+#include <gnuradio/blocklib/blocks/dummy.hpp>
+#include <gnuradio/blocklib/blocks/throttle.hpp>
+#include <gnuradio/blocklib/blocks/vector_sink.hpp>
+#include <gnuradio/blocklib/blocks/vector_source.hpp>
+#include <gnuradio/flowgraph.hpp>
+#include <gnuradio/schedulers/simplestream/scheduler_simplestream.hpp>
+
+using namespace gr;
+
+int main(int argc, char* argv[])
+{
+    auto src = blocks::vector_source_f::make(
+        std::vector<float>{ 1.0, 2.0, 3.0, 4.0, 5.0 }, false);
+    auto snk1 = blocks::vector_sink_f::make();
+    auto snk2 = blocks::vector_sink_f::make();
+
+
+    flowgraph_sptr fg(new flowgraph());
+    fg->connect(src->base(), 0, snk1->base(), 0);
+    fg->connect(src->base(), 0, snk2->base(), 0);
+
+    std::shared_ptr<schedulers::scheduler_simplestream> sched(
+        new schedulers::scheduler_simplestream());
+    fg->set_scheduler(sched->base());
+
+    fg->validate();
+
+    fg->start();
+    fg->wait();
+
+    for (const auto& d : snk1->data())
+        std::cout << d << ' ';
+    std::cout << std::endl;
+
+    for (const auto& d : snk2->data())
+        std::cout << d << ' ';
+    std::cout << std::endl;
+
+}


### PR DESCRIPTION
Create copying mechanism so that a single block with multiple blocks attached to a single port are handled.  
