### PR TITLE
Move unit testing over to GTest

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,17 +1,44 @@
 name: build and run tests
 on:
   push:
-    branches: [ modular, master ]
+    branches: [master]
   pull_request:
-    branches: [ modular, master ]
+    branches: [master]
 jobs:
-  build:
+  # build:
+  # runs-on: ubuntu-20.04
+  # steps:
+  #   - uses: actions/checkout@v2
+  #   # install dependencies
+  #   - name: dependencies
+  #     run: sudo apt-get update && sudo apt-get install -yq libboost-dev libboost-program-options-dev libzmq3-dev python3-mako doxygen libspdlog-dev libyaml-cpp-dev python3-pip && pip3 install meson
+  #   # build volk
+  #   - name: build_volk
+  #     run: mkdir -p volk && curl -Lo volk.tar.gz https://github.com/gnuradio/volk/archive/v2.1.0.tar.gz && tar xzf volk.tar.gz -C volk --strip-components=1 && cmake -DCMAKE_BUILD_TYPE=Release -S ./volk/ -B build && cd build && cmake --build . && sudo cmake --build . --target install && cd ../ && rm -rf build
+  #   # setup newsched
+  #   - name: setup and compile
+  #     run: meson setup build --buildtype=debugoptimized -Denable_testing=true && meson compile -C build
+  #   # run tests
+  #   - name: test
+  #     run: meson test -C build
+
+  linux:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-    # install dependencies
-    - name: dependencies
-      run: sudo apt-get update && sudo apt-get install -yq libboost-dev libboost-program-options-dev libzmq3-dev python3-mako doxygen libspdlog-dev libyaml-cpp-dev
-    # build volk
-    - name: build_volk
-      run: mkdir -p volk && curl -Lo volk.tar.gz https://github.com/gnuradio/volk/archive/v2.1.0.tar.gz && tar xzf volk.tar.gz -C volk --strip-components=1 && cmake -DCMAKE_BUILD_TYPE=Release -S ./volk/ -B build && cd build && cmake --build . && sudo cmake --build . --target install && cd ../ && rm -rf build
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+        with:
+          python-version: "3.x"
+      - run: sudo apt-get update && sudo apt-get install -yq libboost-dev libboost-program-options-dev libzmq3-dev doxygen libspdlog-dev libyaml-cpp-dev libgtest-dev
+      - run: pip install meson ninja mako six
+      - name: build_volk
+        run: mkdir -p volk && curl -Lo volk.tar.gz https://github.com/gnuradio/volk/archive/v2.2.1.tar.gz && tar xzf volk.tar.gz -C volk --strip-components=1 && cmake -DCMAKE_BUILD_TYPE=Release -S ./volk/ -B build && cd build && cmake --build . && sudo cmake --build . --target install && cd ../ && rm -rf build
+      - run: meson setup build --buildtype=debugoptimized -Denable_testing=true
+        env:
+          CC: gcc
+      - run: meson test -C build -v
+      - uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: Linux_Meson_Testlog
+          path: build/meson-logs/testlog.txt

--- a/meson.build
+++ b/meson.build
@@ -12,6 +12,8 @@ yaml_dep = dependency('yaml-cpp', version : '>=0.6')
 spdlog_dep = dependency('spdlog')
 threads_dep = dependency('threads')
 catch_dep = declare_dependency(include_directories : [join_paths('deps','catch','include')])
+gtest_dep = dependency('gtest', main : true, version : '>=1.10', required : get_option('enable_testing'))
+# gmock_dep = dependency('gmock', main : true, version : '>=1.10', required : get_option('enable_testing'))
 
 ## Not sure yet how to search for ZMQ as dependency (header only, no pkgconfig)
 # zmq_dep = dependency('cppzmq')

--- a/schedulers/st/test/meson.build
+++ b/schedulers/st/test/meson.build
@@ -31,7 +31,7 @@ if get_option('enable_testing')
         dependencies: [newsched_runtime_dep,
                     newsched_blocklib_blocks_dep,
                     newsched_scheduler_st_dep,
-                    catch_dep], 
+                    gtest_dep], 
         install : false)
     test('Single Threaded Scheduler Tests', e)
 endif

--- a/schedulers/st/test/qa_scheduler_st.cpp
+++ b/schedulers/st/test/qa_scheduler_st.cpp
@@ -1,7 +1,4 @@
-// #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
-// #include <doctest.h>
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <gtest/gtest.h>
 
 #include <chrono>
 #include <iostream>
@@ -19,7 +16,7 @@
 using namespace gr;
 
 
-TEST_CASE("block outputs one output to 2 input blocks")
+TEST(SchedulerSTTest, TwoSinks)
 {
     std::vector<float> input_data{ 1.0, 2.0, 3.0, 4.0, 5.0 };
     auto src = blocks::vector_source_f::make(input_data, false);
@@ -40,12 +37,12 @@ TEST_CASE("block outputs one output to 2 input blocks")
     fg->start();
     fg->wait();
 
-    REQUIRE_THAT(snk1->data(), Catch::Equals(input_data));
-    REQUIRE_THAT(snk2->data(), Catch::Equals(input_data));
+    EXPECT_EQ(snk1->data(), input_data);
+    EXPECT_EQ(snk2->data(), input_data);
 }
 
-#if 1
-TEST_CASE("Two schedulers connected by domain adapters internally")
+
+TEST(SchedulerSTTest, DomainAdapterBasic)
 {
     std::vector<float> input_data{ 1.0, 2.0, 3.0, 4.0, 5.0 };
 
@@ -84,12 +81,10 @@ TEST_CASE("Two schedulers connected by domain adapters internally")
     fg->start();
     fg->wait();
 
-    REQUIRE_THAT(snk->data(), Catch::Equals(expected_data));
+    EXPECT_EQ(snk->data(), expected_data);
 }
-#endif
 
-#if 1
-TEST_CASE("2 sinks, query and set parameters while FG is running")
+TEST(SchedulerSTTest, ParameterBasic)
 {
     auto src = blocks::vector_source_f::make(
         std::vector<float>{ 1.0, 2.0, 3.0, 4.0, 5.0 }, true);
@@ -136,10 +131,9 @@ TEST_CASE("2 sinks, query and set parameters while FG is running")
     std::cout << "fg stopped" << std::endl;
 
     // now look at the data
-    REQUIRE(snk1->data().size() > 5);
-    REQUIRE(snk2->data().size() > 5);
+    EXPECT_GT(snk1->data().size(), 5);
+    EXPECT_GT(snk2->data().size(), 5);
 
     // TODO - check for query
     // TODO - set changes at specific sample numbers
 }
-#endif


### PR DESCRIPTION
Because Catch2 is header only, compile times for the unit tests are ridiculous.  For example, moving to GTest reduces the compile time of qa_scheduler_st.cpp from 50 seconds down to 20 seconds.  Also, supposedly debugging gtest is supposed to be easier.