### PR TITLE
Runtime optimizations to get down below TPB performance

### DIFF
--- a/runtime/include/gnuradio/scheduler.hpp
+++ b/runtime/include/gnuradio/scheduler.hpp
@@ -53,7 +53,7 @@ public:
             std::make_shared<param_change_action>(blkid, param_action, cb_when_complete));
     }
 
-    virtual void request_callback(const std::string& block_alias,
+    virtual void request_callback(const std::string& block_alias,  // FIXME: change to nodeid
                                   const callback_args& args,
                                   block_callback_complete_fcn cb_when_complete)
     {

--- a/schedulers/st/include/gnuradio/schedulers/st/thread_wrapper.hpp
+++ b/schedulers/st/include/gnuradio/schedulers/st/thread_wrapper.hpp
@@ -37,6 +37,10 @@ private:
     std::vector<neighbor_interface_info> sched_to_notify_upstream,
         sched_to_notify_downstream;
 
+    static const uint8_t flag_blkd_in = 0x01;
+    static const uint8_t flag_blkd_out = 0x02;
+    uint8_t _flags = 0x00;
+
 public:
     typedef std::unique_ptr<thread_wrapper> ptr;
 

--- a/schedulers/st/include/gnuradio/schedulers/st/thread_wrapper.hpp
+++ b/schedulers/st/include/gnuradio/schedulers/st/thread_wrapper.hpp
@@ -33,6 +33,10 @@ private:
     std::string _name;
     int _id;
 
+    scheduler_action_sptr canned_notify_all;
+    std::vector<neighbor_interface_info> sched_to_notify_upstream,
+        sched_to_notify_downstream;
+
 public:
     typedef std::unique_ptr<thread_wrapper> ptr;
 

--- a/schedulers/st/lib/graph_executor.cpp
+++ b/schedulers/st/lib/graph_executor.cpp
@@ -21,7 +21,7 @@ graph_executor::run_one_iteration(std::vector<block_sptr> blocks)
 
         // for each input port of the block
         bool ready = true;
-        for (auto p : b->input_stream_ports()) {
+        for (auto& p : b->input_stream_ports()) {
             auto p_buf = _bufman->get_input_buffer(p);
 
             buffer_info_t read_info;
@@ -48,7 +48,7 @@ graph_executor::run_one_iteration(std::vector<block_sptr> blocks)
         }
 
         // for each output port of the block
-        for (auto p : b->output_stream_ports()) {
+        for (auto& p : b->output_stream_ports()) {
 
             // When a block has multiple output buffers, it adds the restriction
             // that the work call can only produce the minimum available across
@@ -58,7 +58,7 @@ graph_executor::run_one_iteration(std::vector<block_sptr> blocks)
 
             void* write_ptr = nullptr;
             uint64_t nitems_written;
-            for (auto p_buf : _bufman->get_output_buffers(p)) {
+            for (auto& p_buf : _bufman->get_output_buffers(p)) {
                 buffer_info_t write_info;
                 ready = p_buf->write_info(write_info);
                 gr_log_debug(_debug_logger,
@@ -171,15 +171,15 @@ graph_executor::run_one_iteration(std::vector<block_sptr> blocks)
 
 
                 int input_port_index = 0;
-                for (auto p : b->input_stream_ports()) {
+                for (auto& p : b->input_stream_ports()) {
                     auto p_buf = _bufman->get_input_buffer(p);
 
                     // Pass the tags according to TPP
                     if (b->tag_propagation_policy() ==
                         tag_propagation_policy_t::TPP_ALL_TO_ALL) {
                         int output_port_index = 0;
-                        for (auto op : b->output_stream_ports()) {
-                            for (auto p_out_buf : _bufman->get_output_buffers(op)) {
+                        for (auto& op : b->output_stream_ports()) {
+                            for (auto& p_out_buf : _bufman->get_output_buffers(op)) {
                                 p_out_buf->add_tags(
                                     work_output[output_port_index].n_produced,
                                     work_input[input_port_index].tags);
@@ -189,9 +189,9 @@ graph_executor::run_one_iteration(std::vector<block_sptr> blocks)
                     } else if (b->tag_propagation_policy() ==
                                tag_propagation_policy_t::TPP_ONE_TO_ONE) {
                         int output_port_index = 0;
-                        for (auto op : b->output_stream_ports()) {
+                        for (auto& op : b->output_stream_ports()) {
                             if (output_port_index == input_port_index) {
-                                for (auto p_out_buf : _bufman->get_output_buffers(op)) {
+                                for (auto& p_out_buf : _bufman->get_output_buffers(op)) {
                                     p_out_buf->add_tags(
                                         work_output[output_port_index].n_produced,
                                         work_input[input_port_index].tags);
@@ -212,9 +212,9 @@ graph_executor::run_one_iteration(std::vector<block_sptr> blocks)
                 }
 
                 int output_port_index = 0;
-                for (auto p : b->output_stream_ports()) {
+                for (auto& p : b->output_stream_ports()) {
                     int j = 0;
-                    for (auto p_buf : _bufman->get_output_buffers(p)) {
+                    for (auto& p_buf : _bufman->get_output_buffers(p)) {
                         if (j > 0) {
                             gr_log_debug(_debug_logger,
                                          "copy_items {} - {}",
@@ -226,7 +226,7 @@ graph_executor::run_one_iteration(std::vector<block_sptr> blocks)
                         }
                         j++;
                     }
-                    for (auto p_buf : _bufman->get_output_buffers(p)) {
+                    for (auto& p_buf : _bufman->get_output_buffers(p)) {
                         // Add the tags that were collected in the work() call
                         if (!work_output[output_port_index].tags.empty()) {
                             p_buf->add_tags(work_output[output_port_index].n_produced,

--- a/schedulers/st/lib/thread_wrapper.cpp
+++ b/schedulers/st/lib/thread_wrapper.cpp
@@ -237,7 +237,8 @@ void thread_wrapper::thread_body(thread_wrapper* top)
 
         // try to pop messages off the queue
         scheduler_message_sptr msg;
-        if (top->pop_message(msg)) // this blocks
+        auto valid = top->pop_message(msg);
+        if (valid) // this blocks
         {
             switch (msg->type()) {
             case scheduler_message_t::SCHEDULER_ACTION: {
@@ -295,6 +296,10 @@ void thread_wrapper::thread_body(thread_wrapper* top)
             default:
                 break;
             }
+        } else {
+            std::this_thread::yield();
+            gr_log_debug(top->_debug_logger, "No message, do work anyway");
+            top->handle_work_notification();
         }
     }
 }


### PR DESCRIPTION
Biggest changes in here:
1) Don't block on the queue waiting for the condition variable (except at the beginning) - return false, yield thread and continue
2) Add flags to indicate whether we are waiting on input/output, and don't process if we are waiting

Parts of this is a bit hacky and I want to clean it up