### PR TITLE
runtime: add block parameters

### DIFF
--- a/blocklib/blocks/include/gnuradio/blocklib/blocks/meson.build
+++ b/blocklib/blocks/include/gnuradio/blocklib/blocks/meson.build
@@ -5,6 +5,7 @@ blocks_headers = [
     'multiply_const.hpp',
     'null_sink.hpp',
     'null_source.hpp',
+    'throttle.hpp',
     'vector_sink.hpp',
     'vector_source.hpp',
 ]

--- a/blocklib/blocks/include/gnuradio/blocklib/blocks/multiply_const.hpp
+++ b/blocklib/blocks/include/gnuradio/blocklib/blocks/multiply_const.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <gnuradio/sync_block.hpp>
+#include <pmt/pmtf_scalar.hpp>
 
 namespace gr {
 namespace blocks {
@@ -9,29 +10,23 @@ template <class T>
 class multiply_const : public sync_block
 {
 public:
+    enum params : uint32_t { id_k, id_vlen, num_params };
+
     typedef std::shared_ptr<multiply_const> sptr;
     static sptr make(const T k, const size_t vlen = 1)
     {
-        auto ptr = std::make_shared<multiply_const>(multiply_const<T>(k,vlen));
-
-        ptr->add_port(port<T>::make("input",
-                                    port_direction_t::INPUT,
-                                    std::vector<size_t>{ vlen }));
-        ptr->add_port(port<T>::make("output",
-                                    port_direction_t::OUTPUT,
-                                    std::vector<size_t>{ vlen }));
-
-        return ptr;
-
+        return std::make_shared<multiply_const>(multiply_const<T>(k, vlen));
     }
     multiply_const(T k, size_t vlen);
 
     virtual work_return_code_t work(std::vector<block_work_input>& work_input,
                                     std::vector<block_work_output>& work_output);
 
-private:
-    T d_k;
-    size_t d_vlen;
+    // TODO: would like to NOT use macros - just don't know just what pattern to use for
+    // now
+
+    DECLARE_SCALAR_PARAM(T, k);
+    DECLARE_SCALAR_PARAM(size_t, vlen);
 };
 
 typedef multiply_const<std::int16_t> multiply_const_ss;

--- a/blocklib/blocks/include/gnuradio/blocklib/blocks/throttle.hpp
+++ b/blocklib/blocks/include/gnuradio/blocklib/blocks/throttle.hpp
@@ -1,0 +1,76 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2005-2011,2013 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ */
+
+#pragma once
+
+#include <gnuradio/sync_block.hpp>
+#include <chrono>
+
+namespace gr {
+namespace blocks {
+
+/*!
+ * \brief throttle flow of samples such that the average rate does
+ * not exceed samples_per_sec.
+ * \ingroup misc_blk
+ *
+ * \details
+ * input: one stream of itemsize; output: one stream of itemsize
+ *
+ * N.B. this should only be used in GUI apps where there is no
+ * other rate limiting block. It is not intended nor effective at
+ * precisely controlling the rate of samples. That should be
+ * controlled by a source or sink tied to sample clock. E.g., a
+ * USRP or audio card.
+ */
+class throttle : virtual public sync_block
+{
+public:
+    typedef std::shared_ptr<throttle> sptr;
+
+    static sptr make(size_t itemsize, double samples_per_sec, bool ignore_tags = true)
+    {
+        auto ptr =
+            std::make_shared<throttle>(itemsize, samples_per_sec, ignore_tags);
+
+        ptr->add_port(untyped_port::make(
+            "input", port_direction_t::INPUT, itemsize));
+
+
+        ptr->add_port(untyped_port::make(
+            "output", port_direction_t::OUTPUT, itemsize));
+
+        return ptr;
+    }
+
+    throttle(size_t itemsize, double samples_per_sec, bool ignore_tags = true);
+    // ~throttle();
+
+    bool start();
+    virtual work_return_code_t work(std::vector<block_work_input>& work_input,
+                                    std::vector<block_work_output>& work_output);
+
+    //! Sets the sample rate in samples per second.
+    void set_sample_rate(double rate);
+
+    //! Get the sample rate in samples per second.
+    double sample_rate() const;
+
+private:
+    std::chrono::time_point<std::chrono::steady_clock> d_start;
+    const size_t d_itemsize;
+    uint64_t d_total_samples;
+    double d_sample_rate;
+    std::chrono::duration<double> d_sample_period;
+    const bool d_ignore_tags;
+};
+
+} /* namespace blocks */
+} /* namespace gr */

--- a/blocklib/blocks/lib/meson.build
+++ b/blocklib/blocks/lib/meson.build
@@ -3,6 +3,7 @@ blocks_sources = [
     'fanout.cpp',
     'head.cpp',
     'multiply_const.cpp',
+    'throttle.cpp',
     'vector_sink.cpp',
     'vector_source.cpp'
 ]

--- a/blocklib/blocks/lib/throttle.cpp
+++ b/blocklib/blocks/lib/throttle.cpp
@@ -1,0 +1,102 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2005-2011 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ */
+
+#include <gnuradio/blocklib/blocks/throttle.hpp>
+#include <cstring>
+#include <limits>
+#include <thread>
+
+namespace gr {
+namespace blocks {
+
+
+throttle::throttle(size_t itemsize, double samples_per_second, bool ignore_tags)
+    : sync_block("throttle"), d_itemsize(itemsize), d_ignore_tags(ignore_tags)
+{
+    set_sample_rate(samples_per_second);
+}
+
+// throttle::~throttle() {}
+
+bool throttle::start()
+{
+    d_start = std::chrono::steady_clock::now();
+    d_total_samples = 0;
+    return block::start();
+}
+
+void throttle::set_sample_rate(double rate)
+{
+    // changing the sample rate performs a reset of state params
+    d_start = std::chrono::steady_clock::now();
+    d_total_samples = 0;
+    d_sample_rate = rate;
+    d_sample_period = std::chrono::duration<double>(1 / rate);
+}
+
+double throttle::sample_rate() const { return d_sample_rate; }
+
+work_return_code_t throttle::work(std::vector<block_work_input>& work_input,
+                                  std::vector<block_work_output>& work_output)
+{
+    // check for updated rx_rate tag
+    // if (!d_ignore_tags) {
+    // uint64_t abs_N = work_input[0].n_items_read;
+    // std::vector<tag_t> all_tags;
+    // get_tags_in_range(all_tags, 0, abs_N, abs_N + noutput_items);
+    // for (const auto& tag : all_tags) {
+    //     if (pmt::eq(tag.key, throttle_rx_rate_pmt)) {
+    //         double new_rate = pmt::to_double(tag.value);
+    //         set_sample_rate(new_rate);
+    //     }
+    // }
+    // }
+
+    // copy all samples output[i] <= input[i]
+    const char* in = (const char*)work_input[0].items;
+    char* out = (char*)work_output[0].items;
+    auto noutput_items = work_output[0].n_items;
+
+    d_total_samples += noutput_items;
+
+    auto now = std::chrono::steady_clock::now();
+    auto expected_time = d_start + d_sample_period * d_total_samples;
+
+    int n = noutput_items;
+    if (expected_time > now) {
+        auto limit_duration =
+            std::chrono::duration<double>(std::numeric_limits<long>::max());
+        // if (expected_time - now > limit_duration) {
+        //     GR_LOG_ALERT(d_logger,
+        //                  "WARNING: Throttle sleep time overflow! You "
+        //                  "are probably using a very low sample rate.");
+        // }
+
+        // We should no longer block inside of a work function since it may not have its
+        // own thread
+        // This should only be done in its own thread
+        std::this_thread::sleep_until(expected_time);
+
+        // need a more intelligent solution to inform the scheduler
+        // to return at a certain time
+        n = 0;
+        d_total_samples -= noutput_items;
+    }
+
+    // TODO: blocks like throttle shouldn't need to do a memcpy, but this would have to be
+    // fixed in the buffering model and a special port type
+    std::memcpy(out, in, n * d_itemsize);
+    work_output[0].n_produced = n;
+    return work_return_code_t::WORK_OK;
+}
+
+
+} /* namespace blocks */
+} /* namespace gr */

--- a/pmt/include/pmt/pmtf.hpp
+++ b/pmt/include/pmt/pmtf.hpp
@@ -44,7 +44,7 @@ public:
 
     void build()
     {
-        std::cout << "fb size: " << _fbb.GetSize() << std::endl;
+        // std::cout << "fb size: " << _fbb.GetSize() << std::endl;
         PmtBuilder pb(_fbb);
         pb.add_data_type(_data_type);
         pb.add_data(_data);
@@ -52,7 +52,7 @@ public:
         _fbb.FinishSizePrefixed(_blob);
         _buf = _fbb.GetBufferPointer();
         _pmt_fb = GetSizePrefixedPmt(_buf);
-        std::cout << "fb size: " << _fbb.GetSize() << std::endl;
+        // std::cout << "fb size: " << _fbb.GetSize() << std::endl;
     }
 
     flatbuffers::Offset<Pmt> build(flatbuffers::FlatBufferBuilder& fbb)

--- a/runtime/include/gnuradio/parameter.hpp
+++ b/runtime/include/gnuradio/parameter.hpp
@@ -1,0 +1,244 @@
+#pragma once
+
+#include <pmt/pmtf.hpp>
+#include <pmt/pmtf_scalar.hpp>
+#include <functional>
+#include <memory>
+#include <queue>
+#include <string>
+#include <vector>
+
+#include <gnuradio/scheduler_message.hpp>
+
+namespace gr {
+
+enum class range_type_t { MIN_MAX, ACCEPTABLE, BLACKLIST };
+enum class param_flags_t {
+    NO_FLAGS = 0,
+    MANDATORY = 1 << 0, // used to indicate that this parameter must be set (if params are
+                        // removed from constructor)
+    CONST =
+        1 << 1, // set at initialization, but cannot be set once a flowgraph is running
+};
+
+class value_check
+{
+    param_type_t _type;
+    int _dim = 0;
+
+public:
+};
+
+template <class T>
+class continuous_range : value_check
+{
+protected:
+    T _min_value;
+    T _max_value;
+
+public:
+    void set_min_value(T);
+    void set_max_value(T);
+    T min_value();
+    T max_value();
+};
+
+template <class T>
+class fixed_set : value_check
+{
+    std::vector<T> acceptable_values;
+};
+
+template <class T>
+class blacklist_set : value_check
+{
+    std::vector<T> blacklist_values;
+};
+
+class param
+{
+public:
+    typedef std::shared_ptr<param> sptr;
+    static sptr
+    make(const uint32_t id, const std::string name, pmtf::pmt_sptr pmt_value = nullptr)
+    {
+        return std::make_shared<param>(id, name, pmt_value);
+    }
+    param(const uint32_t id, const std::string name, pmtf::pmt_sptr pmt_value)
+        : _id(id), _name(name), _pmt_value(pmt_value)
+    {
+    }
+    virtual ~param() {}
+    std::string to_string() { return ""; };
+
+    const auto id() { return _id; }
+    const auto name() { return _name; }
+    const auto pmt_value() { return _pmt_value; }
+
+    void set_pmt_value(pmtf::pmt_sptr val) { _pmt_value = val; };
+
+
+protected:
+    const uint32_t _id;
+    const std::string _name;
+    param_type_t _type; // should be some sort of typeinfo, but worst case enum or string
+    pmtf::pmt_sptr _pmt_value;
+};
+
+template <class T>
+class scalar_param : public param
+{
+public:
+    typedef std::shared_ptr<scalar_param> sptr;
+    static sptr make(const uint32_t id, const std::string name, T value)
+    {
+        return std::make_shared<scalar_param<T>>(id, name, value);
+    }
+    scalar_param<T>(const uint32_t id, const std::string name, T value)
+        : param(id, name, pmtf::pmt_scalar<T>::make(value)), _value(value)
+    {
+    }
+    virtual ~scalar_param<T>() {}
+
+    void set_value(T val)
+    {
+        std::static_pointer_cast<pmtf::pmt_scalar<T>>(pmt_value())->set_pmt_value(val);
+    }
+    T value()
+    {
+        return std::static_pointer_cast<pmtf::pmt_scalar<T>>(pmt_value())->value();
+    }
+
+protected:
+    T _value;
+};
+
+#define DECLARE_SCALAR_PARAM(type, name)                                     \
+public:                                                                      \
+    void set_##name(type name)                                               \
+    {                                                                        \
+        return request_parameter_change(params::id_##name,                   \
+                                        pmtf::pmt_scalar<type>::make(name)); \
+    }                                                                        \
+    type name()                                                              \
+    {                                                                        \
+        return std::static_pointer_cast<pmtf::pmt_scalar<type>>(             \
+                   request_parameter_query(params::id_##name))               \
+            ->value();                                                       \
+    }                                                                        \
+                                                                             \
+private:                                                                     \
+    typename scalar_param<type>::sptr d_##name;
+    // typename scalar_param<type> d_##name;
+
+class param_action
+{
+protected:
+    uint32_t _id;
+    pmtf::pmt_sptr _pmt_value;
+    uint64_t _at_sample;
+
+public:
+    typedef std::shared_ptr<param_action> sptr;
+    static sptr
+    make(uint32_t id, pmtf::pmt_sptr pmt_value = nullptr, uint64_t at_sample = 0)
+    {
+        return std::make_shared<param_action>(id, pmt_value, at_sample);
+    }
+    param_action(uint32_t id, pmtf::pmt_sptr pmt_value, uint64_t at_sample)
+        : _id(id), _pmt_value(pmt_value), _at_sample(at_sample)
+    {
+    }
+    uint32_t id() const { return _id; }
+    pmtf::pmt_sptr pmt_value() { return _pmt_value; }
+    void set_pmt_value(pmtf::pmt_sptr val) { _pmt_value = val; }
+    uint64_t at_sample() { return _at_sample; }
+    void set_at_sample(uint64_t val) { _at_sample = val; }
+};
+
+typedef std::shared_ptr<param_action> param_action_sptr;
+
+typedef std::function<void(param_action_sptr)> param_action_complete_fcn;
+class param_action_with_callback : public scheduler_message
+{
+public:
+    param_action_with_callback(scheduler_message_t action_type,
+                               nodeid_t block_id,
+                               param_action_sptr param_action,
+                               param_action_complete_fcn cb_fcn)
+        : scheduler_message(action_type), _param_action(param_action), _cb_fcn(cb_fcn)
+    {
+        set_blkid(block_id);
+    }
+    param_action_sptr param_action() { return _param_action; }
+    param_action_complete_fcn cb_fcn() { return _cb_fcn; }
+
+private:
+    param_action_sptr _param_action;
+    param_action_complete_fcn _cb_fcn;
+};
+
+typedef std::queue<param_action_with_callback> param_action_queue;
+
+typedef std::shared_ptr<param> param_sptr;
+
+class param_query_action : public param_action_with_callback
+{
+public:
+    param_query_action(nodeid_t block_id,
+                       param_action_sptr param_action,
+                       param_action_complete_fcn cb_fcn)
+        : param_action_with_callback(
+              scheduler_message_t::PARAMETER_QUERY, block_id, param_action, cb_fcn)
+    {
+    }
+};
+
+class param_change_action : public param_action_with_callback
+{
+public:
+    param_change_action(nodeid_t block_id,
+                        param_action_sptr param_action,
+                        param_action_complete_fcn cb_fcn)
+        : param_action_with_callback(
+              scheduler_message_t::PARAMETER_CHANGE, block_id, param_action, cb_fcn)
+    {
+    }
+};
+
+class parameter_config
+{
+private:
+    std::vector<param_sptr> params;
+
+public:
+    size_t num() { return params.size(); }
+    void add(param_sptr b) { params.push_back(b); }
+    param_sptr get(const uint32_t id)
+    {
+        auto pred = [id](param_sptr item) { return item->id() == id; };
+        std::vector<param_sptr>::iterator it =
+            std::find_if(std::begin(params), std::end(params), pred);
+
+        if (it == std::end(params))
+            throw std::runtime_error(
+                "parameter not defined for this block"); // TODO logging
+
+        return *it;
+    }
+    param_sptr get(const std::string& name)
+    {
+        auto pred = [name](param_sptr item) { return item->name() == name; };
+        std::vector<param_sptr>::iterator it =
+            std::find_if(std::begin(params), std::end(params), pred);
+
+        if (it == std::end(params))
+            throw std::runtime_error(
+                "parameter not defined for this block"); // TODO logging
+
+        return *it;
+    }
+    void clear() { params.clear(); }
+};
+
+} // namespace gr

--- a/runtime/include/gnuradio/scheduler_message.hpp
+++ b/runtime/include/gnuradio/scheduler_message.hpp
@@ -10,6 +10,8 @@ enum class scheduler_action_t { DONE, NOTIFY_OUTPUT, NOTIFY_INPUT, NOTIFY_ALL, E
 enum class scheduler_message_t {
     SCHEDULER_ACTION,
     MSGPORT_MESSAGE,
+    PARAMETER_CHANGE,
+    PARAMETER_QUERY,
 };
 
 class scheduler_message

--- a/runtime/lib/block.cpp
+++ b/runtime/lib/block.cpp
@@ -1,0 +1,58 @@
+
+#include <gnuradio/block.hpp>
+#include <gnuradio/scheduler.hpp>
+
+namespace gr {
+void block::request_parameter_change(int param_id, pmtf::pmt_sptr new_value)
+{
+    // call back to the scheduler if ptr is not null
+    if (p_scheduler && d_running) {
+        std::condition_variable cv;
+        std::mutex m;
+        auto lam = [&](param_action_sptr a) {
+            std::unique_lock<std::mutex> lk(m);
+            cv.notify_one();
+        };
+
+        p_scheduler->push_message(std::make_shared<param_change_action>(
+            id(), param_action::make(param_id, new_value, 0), lam));
+
+        // block until confirmation that parameter has been set
+        std::unique_lock<std::mutex> lk(m);
+        cv.wait(lk);
+    }
+    // else go ahead and update parameter value
+    else {
+        on_parameter_change(param_action::make(param_id, new_value, 0));
+    }
+}
+
+pmtf::pmt_sptr block::request_parameter_query(int param_id)
+{
+    // call back to the scheduler if ptr is not null
+    if (p_scheduler && d_running) {
+        std::condition_variable cv;
+        std::mutex m;
+        pmtf::pmt_sptr newval;
+        auto lam = [&](param_action_sptr a) {
+            std::unique_lock<std::mutex> lk(m);
+            newval = a->pmt_value();
+            cv.notify_one();
+        };
+
+        auto msg = std::make_shared<param_query_action>(
+            id(), param_action::make(param_id), lam);
+        p_scheduler->push_message(msg);
+
+        std::unique_lock<std::mutex> lk(m);
+        cv.wait(lk);
+        return newval;
+    }
+    // else go ahead and return parameter value
+    else {
+        auto action = param_action::make(param_id);
+        on_parameter_query(action);
+        return action->pmt_value();
+    }
+}
+} // namespace gr

--- a/runtime/lib/meson.build
+++ b/runtime/lib/meson.build
@@ -27,6 +27,7 @@ endif
 runtime_sources = [
   'realtime.cpp',
   'parameter_types.cpp',
+  'block.cpp',
   'edge.cpp',
   'graph.cpp',
   'graph_utils.cpp',

--- a/schedulers/mt/include/gnuradio/schedulers/mt/thread_wrapper.hpp
+++ b/schedulers/mt/include/gnuradio/schedulers/mt/thread_wrapper.hpp
@@ -79,6 +79,8 @@ public:
 
     bool handle_work_notification();
     static void thread_body(thread_wrapper* top);
+    void handle_parameter_query(std::shared_ptr<param_query_action> item);
+    void handle_parameter_change(std::shared_ptr<param_change_action> item);
 };
 } // namespace schedulers
 } // namespace gr

--- a/schedulers/mt/lib/scheduler_mt.cpp
+++ b/schedulers/mt/lib/scheduler_mt.cpp
@@ -132,12 +132,8 @@ void scheduler_mt::wait()
 }
 void scheduler_mt::run()
 {
-    for (const auto& thd : _threads) {
-        thd->start();
-    }
-    for (const auto& thd : _threads) {
-        thd->wait();
-    }
+    start();
+    wait();
 }
 
 } // namespace schedulers

--- a/schedulers/mt/test/meson.build
+++ b/schedulers/mt/test/meson.build
@@ -38,6 +38,17 @@ if get_option('enable_testing')
         install : true)
     # test('MT Message Port Tests', e)
 
+    srcs = ['qa_parameters.cpp']
+    e = executable('qa_parameters', 
+        srcs, 
+        include_directories : incdir, 
+        dependencies: [newsched_runtime_dep,
+                    newsched_blocklib_blocks_dep,
+                    newsched_scheduler_mt_dep,
+                    gtest_dep], 
+        install : true)
+    test('MT Parameters Tests', e)
+
 endif
 
 if cuda_dep.found() and get_option('enable_cuda')

--- a/schedulers/mt/test/qa_parameters.cpp
+++ b/schedulers/mt/test/qa_parameters.cpp
@@ -1,0 +1,82 @@
+#include <gtest/gtest.h>
+
+#include <iostream>
+#include <thread>
+
+#include <gnuradio/blocklib/blocks/multiply_const.hpp>
+#include <gnuradio/blocklib/blocks/throttle.hpp>
+#include <gnuradio/blocklib/blocks/vector_sink.hpp>
+#include <gnuradio/blocklib/blocks/vector_source.hpp>
+#include <gnuradio/domain_adapter_direct.hpp>
+#include <gnuradio/flowgraph.hpp>
+#include <gnuradio/schedulers/mt/scheduler_mt.hpp>
+
+using namespace gr;
+
+TEST(SchedulerSTTest, ParameterBasic)
+{
+    auto src = blocks::vector_source_f::make(
+        std::vector<float>{ 1.0, 2.0, 3.0, 4.0, 5.0 }, true);
+    auto throttle = blocks::throttle::make(sizeof(float), 32000);
+    auto mult1 = blocks::multiply_const_ff::make(100.0);
+    auto snk1 = blocks::vector_sink_f::make();
+    auto snk2 = blocks::vector_sink_f::make();
+
+    flowgraph_sptr fg(new flowgraph());
+    fg->connect(src, 0, throttle, 0);
+    fg->connect(throttle, 0, mult1, 0);
+    fg->connect(mult1, 0, snk1, 0);
+    fg->connect(mult1, 0, snk2, 0);
+
+    auto sched = schedulers::scheduler_mt::make("sched1", 4096);
+    fg->set_scheduler(sched);
+
+    fg->validate();
+    fg->start();
+
+    auto start = std::chrono::steady_clock::now();
+
+    float k = 1.0;
+
+    std::vector<float> k_set;
+    std::vector<float> k_queried;
+
+    while (true) {
+        mult1->set_k(k);
+        k_set.push_back(k);
+
+        if (std::chrono::steady_clock::now() - start > std::chrono::seconds(1))
+            break;
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+        k += 1.0;
+
+        auto query_k = mult1->k();
+        // std::cout << query_k << std::endl;
+        k_queried.push_back(query_k);
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+
+    fg->stop();
+
+    // Search for the values that we set in the values we queried
+    bool all_values_found = true;
+    for (unsigned i = 0; i<k_set.size()-1; i++)
+    {
+        if (std::find(k_queried.begin(), k_queried.end(), k_set[i]) == k_queried.end())
+        {
+            all_values_found = false;
+        }
+    }
+
+    EXPECT_TRUE(all_values_found);
+
+    // now look at the data
+    EXPECT_GT(snk1->data().size(), 5);
+    EXPECT_GT(snk2->data().size(), 5);
+
+    // TODO - check for query
+    // TODO - set changes at specific sample numbers
+}


### PR DESCRIPTION
parameters provide a mechanism so that changes to a value of a block can
be centralized and made threadsafe.  Parameters can be extended so that
the registered values can be updated via tags, RPC, etc without extra
code in each block.  This is only implemented here on the multiply_const
block as a proof of concept