### PR TITLE
runtime: default scheduler as mt using dlsym

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -5,26 +5,51 @@ on:
   pull_request:
     branches: [master]
 jobs:
-  linux:
+  linux-docker:
+  # All of these shall depend on the formatting check (needs: check-formatting)
     runs-on: ubuntu-20.04
+    # The GH default is 360 minutes (it's also the max as of Feb-2021). However
+    # we should fail sooner. The only reason to exceed this time is if a test
+    # hangs.
+    timeout-minutes: 120
+    strategy:
+      # Enabling fail-fast would kill all Dockers if one of them fails. We want
+      # maximum output.
+      fail-fast: false
+      matrix:
+        # For every distro we want to test here, add one key 'distro' with a
+        # descriptive name, and one key 'containerid' with the name of the
+        # container (i.e., what you want to docker-pull)
+        include:
+          - distro: 'Ubuntu 20.04'
+            containerid: 'mormj/newsched-ci-docker'
+            cxxflags: -Werror
+          # - distro: 'Fedora 33'
+          #   containerid: 'gnuradio/ci:fedora-33-3.9'
+          #   cxxflags: ''
+          # - distro: 'CentOS 8.3'
+          #   containerid: 'gnuradio/ci:centos-8.3-3.9'
+          #   cxxflags: -Werror
+          # - distro: 'Debian 10'
+          #   containerid: 'gnuradio/ci-debian-10-3.9:1.0'
+          #   cxxflags: -Werror
+    name: ${{ matrix.distro }}
+    container:
+      image: ${{ matrix.containerid }}
+      volumes:
+        - build_data:/build
+      options: --cpus 2
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
-        with:
-          python-version: "3.x"
-      - run: sudo apt-get update && sudo apt-get install -yq libboost-dev libboost-program-options-dev libzmq3-dev doxygen libspdlog-dev libyaml-cpp-dev libgtest-dev libfmt-dev pybind11-dev python3-dev python3-numpy
-      - run: pip install meson ninja mako six jinja2 pyyaml
-      - name: build_volk
-        run: mkdir -p volk && curl -Lo volk.tar.gz https://github.com/gnuradio/volk/archive/v2.2.1.tar.gz && tar xzf volk.tar.gz -C volk --strip-components=1 && cmake -DCMAKE_BUILD_TYPE=Release -S ./volk/ -B build && cd build && cmake --build . && sudo cmake --build . --target install && cd ../ && rm -rf build
-      - name: build_flatc
-        run: git clone https://github.com/google/flatbuffers.git && cd flatbuffers && git checkout aafc5dc9500f01c64 && mkdir build && cd build && cmake ../ && sudo make install -j 
-      - run: meson setup build --buildtype=debugoptimized -Denable_testing=true
-        env:
-          CC: gcc
-      - run: cd build && ninja && ninja
-      - run: cd build && ninja test
-      - uses: actions/upload-artifact@v1
-        if: failure()
-        with:
-          name: Linux_Meson_Testlog
-          path: build/meson-logs/testlog.txt
+    - uses: actions/checkout@v2
+      name: Checkout Project
+    - name: Meson Setup
+      run: 'cd ${GITHUB_WORKSPACE} && meson setup build --buildtype=debugoptimized -Denable_testing=true' 
+    - name: Make
+      run: 'cd ${GITHUB_WORKSPACE}/build && ninja'
+    - name: Make Test
+      run: 'cd ${GITHUB_WORKSPACE}/build && ninja test'
+    - uses: actions/upload-artifact@v1
+      if: failure()
+      with:
+        name: Linux_Meson_Testlog
+        path: build/meson-logs/testlog.txt

--- a/blocklib/blocks/python/blocks/meson.build
+++ b/blocklib/blocks/python/blocks/meson.build
@@ -31,7 +31,7 @@ gen_blocks_pybind = custom_target('gen_blocks_pybind',
 
 blocks_pybind_sources += gen_blocks_pybind
 
-newsched_blocklib_blocks_pybind = py3_mod.extension_module('blocks_python',
+newsched_blocklib_blocks_pybind = py3_inst.extension_module('blocks_python',
     blocks_pybind_sources, 
     dependencies : [newsched_blocklib_blocks_dep, python3_dep, pybind11_dep],
     link_language : 'cpp',

--- a/meson.build
+++ b/meson.build
@@ -8,6 +8,7 @@ project('newsched', 'cpp',
 
 cc = meson.get_compiler('cpp')
 rt_dep = cc.find_library('rt', required : false)
+libdl_dep = cc.find_library('dl')
 
 cuda_available = add_languages('cuda', required : false)
 

--- a/meson.build
+++ b/meson.build
@@ -20,7 +20,6 @@ spdlog_dep = dependency('spdlog', method: 'cmake', modules : ['spdlog::spdlog'])
 python3_dep = dependency('python3', required : get_option('enable_python'))
 
 # Import python3 meson module which is used to find the Python dependencies.
-py3_mod = import('python3')
 py3_inst = import('python').find_installation('python3')
 
 pybind11_dep = dependency('pybind11', required : get_option('enable_python'))

--- a/runtime/include/gnuradio/flowgraph.hh
+++ b/runtime/include/gnuradio/flowgraph.hh
@@ -23,6 +23,11 @@ private:
     flowgraph_monitor_sptr d_fgmon;
     bool _validated = false; // TODO - update when connections are added or things are changed
 
+    // Dynamically Loaded Default Scheduler
+    const std::string s_default_scheduler_name = "mt";
+    scheduler_sptr d_default_scheduler = nullptr;
+    bool d_default_scheduler_inuse = true;
+
 public:
     
     typedef std::shared_ptr<flowgraph> sptr;

--- a/runtime/lib/meson.build
+++ b/runtime/lib/meson.build
@@ -3,7 +3,7 @@ incdir = [
 ]
 
 
-runtime_deps = [yaml_dep, spdlog_dep, threads_dep, fmt_dep, rt_dep, pmtf_dep]
+runtime_deps = [yaml_dep, spdlog_dep, threads_dep, fmt_dep, rt_dep, pmtf_dep, libdl_dep]
 
 if cuda_dep.found() and get_option('enable_cuda')
   cu_sources = [

--- a/runtime/python/gr/bindings/meson.build
+++ b/runtime/python/gr/bindings/meson.build
@@ -11,7 +11,7 @@ runtime_pybind_sources = files([
     'scheduler_pybind.cc'
  ] )
 
-newsched_runtime_pybind = py3_mod.extension_module('runtime_python',
+newsched_runtime_pybind = py3_inst.extension_module('runtime_python',
     runtime_pybind_sources, 
     dependencies : [newsched_runtime_dep, python3_dep, pybind11_dep, pmtf_dep],
     link_language : 'cpp',

--- a/schedulers/mt/lib/scheduler_mt.cc
+++ b/schedulers/mt/lib/scheduler_mt.cc
@@ -16,13 +16,15 @@ void scheduler_mt::push_message(scheduler_message_sptr msg)
     }
 }
 
-void scheduler_mt::add_block_group(const std::vector<block_sptr>& blocks, const std::string& name, const std::vector<unsigned int>& affinity_mask)
+void scheduler_mt::add_block_group(const std::vector<block_sptr>& blocks,
+                                   const std::string& name,
+                                   const std::vector<unsigned int>& affinity_mask)
 {
-    _block_groups.push_back(std::move(block_group_properties(blocks, name, affinity_mask)));
+    _block_groups.push_back(
+        std::move(block_group_properties(blocks, name, affinity_mask)));
 }
 
-void scheduler_mt::initialize(flat_graph_sptr fg,
-                              flowgraph_monitor_sptr fgmon)
+void scheduler_mt::initialize(flat_graph_sptr fg, flowgraph_monitor_sptr fgmon)
 {
     for (auto& b : fg->calc_used_blocks()) {
         b->set_scheduler(base());
@@ -42,8 +44,7 @@ void scheduler_mt::initialize(flat_graph_sptr fg,
         std::vector<block_sptr> blocks_for_this_thread;
 
         if (bg.blocks().size()) {
-            auto t = thread_wrapper::make(
-                 id(), bg, bufman, fgmon);
+            auto t = thread_wrapper::make(id(), bg, bufman, fgmon);
             _threads.push_back(t);
 
             std::vector<node_sptr> node_vec;
@@ -69,8 +70,7 @@ void scheduler_mt::initialize(flat_graph_sptr fg,
         std::vector<node_sptr> node_vec;
         node_vec.push_back(b);
 
-        auto t =
-            thread_wrapper::make(id(), block_group_properties({b}), bufman, fgmon);
+        auto t = thread_wrapper::make(id(), block_group_properties({ b }), bufman, fgmon);
         _threads.push_back(t);
 
         for (auto& p : b->all_ports()) {
@@ -111,3 +111,13 @@ void scheduler_mt::run()
 
 } // namespace schedulers
 } // namespace gr
+
+
+// External plugin interface for instantiating out of tree schedulers
+// TODO: name, version, other info methods
+extern "C" {
+std::shared_ptr<gr::scheduler> factory(const std::string& name = "mt", size_t buf_size = 32768)
+{
+    return gr::schedulers::scheduler_mt::make(name, buf_size);
+}
+}

--- a/schedulers/mt/python/schedulers/mt/bindings/meson.build
+++ b/schedulers/mt/python/schedulers/mt/bindings/meson.build
@@ -2,7 +2,7 @@ scheduler_mt_pybind_sources = files([
 'scheduler_mt_pybind.cc'
  ] )
 
-newsched_scheduler_mt_pybind = py3_mod.extension_module('scheduler_mt_python',
+newsched_scheduler_mt_pybind = py3_inst.extension_module('scheduler_mt_python',
     scheduler_mt_pybind_sources, 
     dependencies : [newsched_runtime_dep, newsched_scheduler_mt_dep, python3_dep, pybind11_dep],
     link_language : 'cpp',

--- a/schedulers/mt/test/meson.build
+++ b/schedulers/mt/test/meson.build
@@ -5,6 +5,10 @@ incdir = include_directories('../include')
 ###################################################
 
 if get_option('enable_testing')
+    env = environment()
+    env.prepend('LD_LIBRARY_PATH', join_paths( meson.build_root(),'schedulers','mt','lib'))
+    env.prepend('PYTHONPATH', join_paths(meson.build_root(),'python'))
+
     srcs = ['qa_scheduler_mt.cc']
     e = executable('qa_scheduler_mt', 
         srcs, 
@@ -15,7 +19,7 @@ if get_option('enable_testing')
                     newsched_scheduler_mt_dep,
                     gtest_dep], 
         install : true)
-    test('Multi Threaded Scheduler Tests', e)
+    test('Multi Threaded Scheduler Tests', e, env: env)
 
     srcs = ['qa_block_grouping.cc']
     e = executable('qa_block_grouping', 
@@ -39,7 +43,8 @@ if get_option('enable_testing')
                     newsched_scheduler_mt_dep,
                     gtest_dep], 
         install : true)
-    test('MT Single Mapped Buffers', e)
+
+    test('MT Single Mapped Buffers', e, env: env)
 
     srcs = ['qa_message_ports.cc']
     e = executable('qa_message_ports', 
@@ -65,9 +70,7 @@ if get_option('enable_testing')
         install : true)
     test('MT Tags Tests', e)
 
-    # env = environment()
-    # env.prepend('PYTHONPATH', join_paths('PYTHONPATH', meson.build_root(),'python'))
-    # test('Basic Python', find_program('qa_basic.py'), env: env)
+    test('Basic Python', find_program('qa_basic.py'), env: env)
 
 endif
 

--- a/schedulers/mt/test/qa_basic.py
+++ b/schedulers/mt/test/qa_basic.py
@@ -21,17 +21,13 @@ class test_basic(gr_unittest.TestCase):
         snk1 = blocks.vector_sink_f()
         snk2 = blocks.vector_sink_f()
 
-        fg = gr.flowgraph()
-        fg.connect(src, 0, cp1, 0)
-        fg.connect(cp1, 0, snk1, 0)
-        fg.connect(src, 0, cp2, 0)
-        fg.connect(cp2, 0, snk2, 0)
+        self.tb.connect(src, 0, cp1, 0)
+        self.tb.connect(cp1, 0, snk1, 0)
+        self.tb.connect(src, 0, cp2, 0)
+        self.tb.connect(cp2, 0, snk2, 0)
 
-        sched = mt.scheduler_mt()
-        fg.set_scheduler(sched)
-
-        fg.start()
-        fg.wait()
+        self.tb.start()
+        self.tb.wait()
 
         self.assertEqual(input_data, snk1.data())
         self.assertEqual(input_data, snk2.data())

--- a/schedulers/mt/test/qa_scheduler_mt.cc
+++ b/schedulers/mt/test/qa_scheduler_mt.cc
@@ -13,7 +13,7 @@
 #include <gnuradio/vmcircbuf.hh>
 
 using namespace gr;
-#if 0
+
 TEST(SchedulerMTTest, TwoSinks)
 {
     int nsamples = 100000;
@@ -26,17 +26,9 @@ TEST(SchedulerMTTest, TwoSinks)
     auto snk2 = blocks::vector_sink_f::make_cpu();
 
 
-    flowgraph_sptr fg(new flowgraph());
+    auto fg = flowgraph::make();
     fg->connect(src, 0, snk1, 0);
     fg->connect(src, 0, snk2, 0);
-
-    auto sched = schedulers::scheduler_mt::make();
-    fg->set_scheduler(sched);
-
-    // force single threaded operation
-    // sched->add_block_group({src,snk1,snk2});
-
-    fg->validate();
 
     fg->start();
     fg->wait();
@@ -46,7 +38,7 @@ TEST(SchedulerMTTest, TwoSinks)
     EXPECT_EQ(snk1->data(), input_data);
     EXPECT_EQ(snk2->data(), input_data);
 }
-
+#if 0
 TEST(SchedulerMTTest, MultiDomainBasic)
 {
     std::vector<float> input_data{ 1.0, 2.0, 3.0, 4.0, 5.0 };
@@ -123,11 +115,6 @@ TEST(SchedulerMTTest, BlockFanout)
             }
         }
 
-        auto sched1 = schedulers::scheduler_mt::make("mtsched", 8192);
-        fg->add_scheduler(sched1);
-        fg->validate();
-
-
         fg->start();
         fg->wait();
 
@@ -173,14 +160,6 @@ TEST(SchedulerMTTest, CustomCPUBuffers)
     fg->connect(copy3, 0, snk2, 0)
         ->set_custom_buffer(vmcirc_buffer_properties::make(vmcirc_buffer_type::AUTO)
                                 ->set_min_buffer_size(16384));
-
-    std::shared_ptr<schedulers::scheduler_mt> sched(new schedulers::scheduler_mt());
-    fg->set_scheduler(sched);
-
-    // force single threaded operation
-    // sched->add_block_group({src,snk1,snk2});
-
-    fg->validate(); 
 
     // TODO: Validate the buffers that were created
 

--- a/schedulers/mt/test/qa_single_mapped_buffers.cc
+++ b/schedulers/mt/test/qa_single_mapped_buffers.cc
@@ -44,11 +44,6 @@ TEST(SchedulerMTSingleBuffers, SingleMappedSimple)
     }
     fg->connect(mult_blks[nblocks - 1], 0, snk, 0);
 
-    auto sched1 = schedulers::scheduler_mt::make("mtsched", 8192);
-    fg->add_scheduler(sched1);
-    fg->validate();
-
-
     fg->start();
     fg->wait();
 
@@ -102,11 +97,6 @@ TEST(SchedulerMTSingleBuffers, SingleMappedFanout)
         fg->connect(src, 0, mult_blks[i], 0)->set_custom_buffer(SM_BUFFER_ARGS);
         fg->connect(mult_blks[i], 0, sink_blks[i], 0)->set_custom_buffer(SM_BUFFER_ARGS);
     }
-
-    auto sched1 = schedulers::scheduler_mt::make("mtsched", 8192);
-    fg->add_scheduler(sched1);
-    fg->validate();
-
 
     fg->start();
     fg->wait();


### PR DESCRIPTION
Dynamically load a default scheduler so it doesn't have to be explicitly configured at runtime

In the future, this should be configurable via preferences, etc.
