### PR TITLE
runtime: Allow items of different sizes to be connected

### DIFF
--- a/runtime/include/gnuradio/buffer.hh
+++ b/runtime/include/gnuradio/buffer.hh
@@ -230,11 +230,13 @@ public:
 
     /**
      * @brief Create a reader object and reference to this buffer
-     *
+     * 
+     * @param buf_props 
+     * @param itemsize itemsize in bytes on the destination side
      * @return std::shared_ptr<buffer_reader>
      */
     virtual std::shared_ptr<buffer_reader>
-    add_reader(std::shared_ptr<buffer_properties> buf_props) = 0;
+    add_reader(std::shared_ptr<buffer_properties> buf_props, size_t itemsize) = 0;
     // void drop_reader(std::shared_ptr<buffer_reader>);
 
     virtual bool output_blocked_callback(bool force = false)
@@ -253,15 +255,18 @@ protected:
     buffer_sptr _buffer; // the buffer that owns this reader
     std::shared_ptr<buffer_properties> _buf_properties;
     uint64_t _total_read = 0;
+    size_t _itemsize;
     size_t _read_index = 0;
     std::mutex _rdr_mutex;
+    
 
 
 public:
     buffer_reader(buffer_sptr buffer,
                   std::shared_ptr<buffer_properties> buf_props,
+                  size_t itemsize,
                   size_t read_index = 0)
-        : _buffer(buffer), _buf_properties(buf_props), _read_index(read_index)
+        : _buffer(buffer), _buf_properties(buf_props), _itemsize(itemsize), _read_index(read_index)
     {
     }
     virtual ~buffer_reader() {}
@@ -283,6 +288,13 @@ public:
      * @return uint64_t
      */
     virtual uint64_t items_available();
+
+    /**
+     * @brief Return the number of bytes available to be read
+     *
+     * @return uint64_t
+     */
+    virtual uint64_t bytes_available();
 
     /**
      * @brief Return current buffer state for reading

--- a/runtime/include/gnuradio/buffer_sm.hh
+++ b/runtime/include/gnuradio/buffer_sm.hh
@@ -71,7 +71,7 @@ public:
     virtual void post_read(int num_items) override;
 
     virtual bool input_blocked_callback(size_t items_required);
-    virtual size_t items_available() override;
+    virtual size_t bytes_available() override;
 };
 
 

--- a/runtime/include/gnuradio/buffer_sm.hh
+++ b/runtime/include/gnuradio/buffer_sm.hh
@@ -48,7 +48,7 @@ public:
 
     virtual bool write_info(buffer_info_t& info) override;
     virtual std::shared_ptr<buffer_reader>
-    add_reader(std::shared_ptr<buffer_properties> buf_props) override;
+    add_reader(std::shared_ptr<buffer_properties> buf_props, size_t itemsize) override;
 
     bool adjust_buffer_data(memcpy_func_t memcpy_func, memmove_func_t memmove_func);
 };
@@ -64,6 +64,7 @@ protected:
 
 public:
     buffer_sm_reader(std::shared_ptr<buffer_sm> buffer,
+                     size_t itemsize,
                      std::shared_ptr<buffer_properties> buf_props = nullptr,
                      size_t read_index = 0);
 

--- a/runtime/include/gnuradio/cudabuffer.hh
+++ b/runtime/include/gnuradio/cudabuffer.hh
@@ -37,14 +37,14 @@ public:
 
     virtual void post_write(int num_items);
 
-    virtual std::shared_ptr<buffer_reader> add_reader(std::shared_ptr<buffer_properties> buf_props);
+    virtual std::shared_ptr<buffer_reader> add_reader(std::shared_ptr<buffer_properties> buf_props, size_t itemsize);
 };
 
 class cuda_buffer_reader : public buffer_reader
 {
 public:
-    cuda_buffer_reader(buffer_sptr buffer,  std::shared_ptr<buffer_properties> buf_props, size_t read_index)
-        : buffer_reader(buffer, buf_props, read_index)
+    cuda_buffer_reader(buffer_sptr buffer,  std::shared_ptr<buffer_properties> buf_props, size_t itemsize, size_t read_index)
+        : buffer_reader(buffer, buf_props, itemsize, read_index)
     {
     }
 

--- a/runtime/include/gnuradio/cudabuffer_pinned.hh
+++ b/runtime/include/gnuradio/cudabuffer_pinned.hh
@@ -30,15 +30,16 @@ public:
     virtual void post_write(int num_items);
 
     virtual std::shared_ptr<buffer_reader>
-    add_reader(std::shared_ptr<buffer_properties> buf_props);
+    add_reader(std::shared_ptr<buffer_properties> buf_props, size_t itemsize);
 };
 class cuda_buffer_pinned_reader : public buffer_reader
 {
 public:
     cuda_buffer_pinned_reader(buffer_sptr buffer,
                               std::shared_ptr<buffer_properties> buf_props,
+                              size_t itemsize,
                               size_t read_index)
-        : buffer_reader(buffer, buf_props, read_index)
+        : buffer_reader(buffer, buf_props, itemsize, read_index)
     {
     }
 

--- a/runtime/include/gnuradio/cudabuffer_sm.hh
+++ b/runtime/include/gnuradio/cudabuffer_sm.hh
@@ -39,7 +39,7 @@ public:
     virtual void post_write(int num_items);
 
     virtual std::shared_ptr<buffer_reader>
-    add_reader(std::shared_ptr<buffer_properties> buf_props);
+    add_reader(std::shared_ptr<buffer_properties> buf_props, size_t itemsize);
 
     static void* cuda_memcpy(void* dest, const void* src, std::size_t count);
     static void* cuda_memmove(void* dest, const void* src, std::size_t count);
@@ -70,8 +70,9 @@ private:
 public:
     cuda_buffer_sm_reader(std::shared_ptr<cuda_buffer_sm> buffer,
                           std::shared_ptr<buffer_properties> buf_props,
+                          size_t itemsize,
                           size_t read_index)
-        : buffer_sm_reader(buffer, buf_props, read_index)
+        : buffer_sm_reader(buffer, itemsize, buf_props, read_index)
     {
         _cuda_buffer_sm = buffer;
         // _logger = logging::get_logger("cudabuffer_sm_reader", "default");

--- a/runtime/include/gnuradio/simplebuffer.hh
+++ b/runtime/include/gnuradio/simplebuffer.hh
@@ -67,7 +67,7 @@ public:
     }
 
     virtual std::shared_ptr<buffer_reader>
-    add_reader(std::shared_ptr<buffer_properties> buf_props);
+    add_reader(std::shared_ptr<buffer_properties> buf_props, size_t itemsize);
 };
 
 class simplebuffer_reader : public buffer_reader
@@ -75,8 +75,9 @@ class simplebuffer_reader : public buffer_reader
 public:
     simplebuffer_reader(buffer_sptr buffer,
                         std::shared_ptr<buffer_properties> buf_props,
+                        size_t itemsize,
                         size_t read_index = 0)
-        : buffer_reader(buffer, buf_props, read_index)
+        : buffer_reader(buffer, buf_props, itemsize, read_index)
     {
     }
 
@@ -85,7 +86,7 @@ public:
         std::scoped_lock guard(_rdr_mutex);
 
         // advance the read pointer
-        _read_index += num_items * _buffer->item_size();
+        _read_index += num_items * _itemsize; // _buffer->item_size();
         if (_read_index >= _buffer->buf_size()) {
             _read_index -= _buffer->buf_size();
         }

--- a/runtime/include/gnuradio/vmcircbuf.hh
+++ b/runtime/include/gnuradio/vmcircbuf.hh
@@ -48,14 +48,14 @@ public:
 
     // virtual void copy_items(std::shared_ptr<buffer> from, int nitems);
 
-    virtual std::shared_ptr<buffer_reader> add_reader(std::shared_ptr<buffer_properties> buf_props);
+    virtual std::shared_ptr<buffer_reader> add_reader(std::shared_ptr<buffer_properties> buf_props, size_t itemsize);
 };
 
 class vmcirc_buffer_reader : public buffer_reader
 {
 public:
-    vmcirc_buffer_reader(buffer_sptr buffer, std::shared_ptr<buffer_properties> buf_props, size_t read_index = 0)
-        : buffer_reader(buffer, buf_props, read_index)
+    vmcirc_buffer_reader(buffer_sptr buffer, std::shared_ptr<buffer_properties> buf_props, size_t itemsize, size_t read_index = 0)
+        : buffer_reader(buffer, buf_props, itemsize, read_index)
     {
     }
 

--- a/runtime/lib/buffer_management.cc
+++ b/runtime/lib/buffer_management.cc
@@ -67,7 +67,7 @@ void buffer_manager::initialize_buffers(flat_graph_sptr fg,
                             ed[0]->identifier(),
                             ed[0]->src().node()->alias());
                 p->set_buffer_reader(
-                    ed[0]->src().port()->buffer()->add_reader(ed[0]->buf_properties()));
+                    ed[0]->src().port()->buffer()->add_reader(ed[0]->buf_properties(), ed[0]->dst().port()->itemsize()));
             }
         }
     }

--- a/runtime/lib/buffer_sm.cc
+++ b/runtime/lib/buffer_sm.cc
@@ -5,10 +5,11 @@
 namespace gr {
 
 std::shared_ptr<buffer_reader>
-buffer_sm::add_reader(std::shared_ptr<buffer_properties> buf_props)
+buffer_sm::add_reader(std::shared_ptr<buffer_properties> buf_props, size_t itemsize)
 {
     std::shared_ptr<buffer_sm_reader> r(
         new buffer_sm_reader(std::dynamic_pointer_cast<buffer_sm>(shared_from_this()),
+                             itemsize,
                              buf_props,
                              _write_index));
     _readers.push_back(r.get());
@@ -29,10 +30,9 @@ buffer_sm::buffer_sm(size_t num_items,
     // _debug_logger = logging::get_logger(_type + "_dbg", "debug");
 }
 
-buffer_sptr
-buffer_sm::make(size_t num_items,
-                size_t item_size,
-                std::shared_ptr<buffer_properties> buffer_properties)
+buffer_sptr buffer_sm::make(size_t num_items,
+                            size_t item_size,
+                            std::shared_ptr<buffer_properties> buffer_properties)
 {
     return buffer_sptr(new buffer_sm(num_items, item_size, buffer_properties));
 }
@@ -58,8 +58,7 @@ void buffer_sm::post_write(int num_items)
     _total_written += num_items;
 }
 
-bool buffer_sm::output_blocked_callback_logic(bool force,
-                                              memmove_func_t memmove_func)
+bool buffer_sm::output_blocked_callback_logic(bool force, memmove_func_t memmove_func)
 {
     auto space_avail = space_available();
 
@@ -234,9 +233,10 @@ bool buffer_sm::adjust_buffer_data(memcpy_func_t memcpy_func, memmove_func_t mem
 
 
 buffer_sm_reader::buffer_sm_reader(std::shared_ptr<buffer_sm> buffer,
+                                    size_t itemsize,
                                    std::shared_ptr<buffer_properties> buf_props,
                                    size_t read_index)
-    : buffer_reader(buffer, buf_props, read_index), _buffer_sm(buffer)
+    : buffer_reader(buffer, buf_props, itemsize, read_index), _buffer_sm(buffer)
 {
     // _logger = logging::get_logger("buffer_sm_reader", "default");
     // _debug_logger = logging::get_logger("buffer_sm_reader_dbg", "debug");
@@ -247,10 +247,10 @@ void buffer_sm_reader::post_read(int num_items)
     std::scoped_lock guard(_rdr_mutex);
 
     // GR_LOG_DEBUG(
-        // _debug_logger, "post_read: _read_index {}, num_items {}", _read_index, num_items);
+    // _debug_logger, "post_read: _read_index {}, num_items {}", _read_index, num_items);
 
     // advance the read pointer
-    _read_index += num_items * _buffer->item_size();
+    _read_index += num_items * _itemsize; //_buffer->item_size();
     _total_read += num_items;
     if (_read_index == _buffer->buf_size()) {
         _read_index = 0;
@@ -310,11 +310,11 @@ size_t buffer_sm_reader::items_available()
     size_t r = _read_index;
 
     if (w < r) {
-        ret = (_buffer->buf_size() - r) / _buffer->item_size();
+        ret = (_buffer->buf_size() - r) / _itemsize; //_buffer->item_size();
     } else if (w == r && total_read() < _buffer->total_written()) {
-        ret = (_buffer->buf_size() - r) / _buffer->item_size();
+        ret = (_buffer->buf_size() - r) / _itemsize; //_buffer->item_size();
     } else {
-        ret = (w - r) / _buffer->item_size();
+        ret = (w - r) / _itemsize; // _buffer->item_size();
     }
 
     // return ret;

--- a/runtime/lib/buffer_sm.cc
+++ b/runtime/lib/buffer_sm.cc
@@ -299,7 +299,7 @@ bool buffer_sm_reader::input_blocked_callback(size_t items_required)
     return false;
 }
 
-size_t buffer_sm_reader::items_available()
+size_t buffer_sm_reader::bytes_available()
 {
     // Can only read up to to the write_index, or the end of the buffer
     // there is no wraparound
@@ -310,11 +310,11 @@ size_t buffer_sm_reader::items_available()
     size_t r = _read_index;
 
     if (w < r) {
-        ret = (_buffer->buf_size() - r) / _itemsize; //_buffer->item_size();
+        ret = (_buffer->buf_size() - r);
     } else if (w == r && total_read() < _buffer->total_written()) {
-        ret = (_buffer->buf_size() - r) / _itemsize; //_buffer->item_size();
+        ret = (_buffer->buf_size() - r); 
     } else {
-        ret = (w - r) / _itemsize; // _buffer->item_size();
+        ret = (w - r);
     }
 
     // return ret;
@@ -328,7 +328,7 @@ size_t buffer_sm_reader::items_available()
     //              total_read(),
     //              _buffer->total_written());
 
-    if (_buffer->total_written() - total_read() < ret) {
+    if (_buffer->total_written() - total_read() < ret * _itemsize) {
         // GR_LOG_DEBUG(_debug_logger,
         //              "check_math {} {} {} {}",
         //              _buffer->total_written() - total_read(),
@@ -337,7 +337,7 @@ size_t buffer_sm_reader::items_available()
         //              _buffer->total_written());
     }
 
-    return ret;
+    return ret; // in bytes
 }
 
 

--- a/runtime/lib/cudabuffer.cu
+++ b/runtime/lib/cudabuffer.cu
@@ -74,7 +74,7 @@ void cuda_buffer_reader::post_read(int num_items)
 {
     std::lock_guard<std::mutex> guard(_rdr_mutex);
     // advance the read pointer
-    _read_index += num_items * _buffer->item_size();
+    _read_index += num_items * _itemsize;
     if (_read_index >= _buffer->buf_size()) {
         _read_index -= _buffer->buf_size();
     }
@@ -148,10 +148,10 @@ void cuda_buffer::post_write(int num_items)
 }
 
 std::shared_ptr<buffer_reader>
-cuda_buffer::add_reader(std::shared_ptr<buffer_properties> buf_props)
+cuda_buffer::add_reader(std::shared_ptr<buffer_properties> buf_props, size_t itemsize)
 {
     std::shared_ptr<cuda_buffer_reader> r(
-        new cuda_buffer_reader(shared_from_this(), buf_props, _write_index));
+        new cuda_buffer_reader(shared_from_this(), buf_props, itemsize, _write_index));
     _readers.push_back(r.get());
     return r;
 }

--- a/runtime/lib/cudabuffer_pinned.cu
+++ b/runtime/lib/cudabuffer_pinned.cu
@@ -34,7 +34,7 @@ void cuda_buffer_pinned_reader::post_read(int num_items)
 {
     std::lock_guard<std::mutex> guard(_rdr_mutex);
     // advance the read pointer
-    _read_index += num_items * _buffer->item_size();
+    _read_index += num_items * _itemsize;
     if (_read_index >= _buffer->buf_size()) {
         _read_index -= _buffer->buf_size();
     }
@@ -65,10 +65,10 @@ void cuda_buffer_pinned::post_write(int num_items)
     }
 }
 
-std::shared_ptr<buffer_reader> cuda_buffer_pinned::add_reader(std::shared_ptr<buffer_properties> buf_props)
+std::shared_ptr<buffer_reader> cuda_buffer_pinned::add_reader(std::shared_ptr<buffer_properties> buf_props, size_t itemsize)
 {
     std::shared_ptr<cuda_buffer_pinned_reader> r(
-        new cuda_buffer_pinned_reader(shared_from_this(), buf_props, _write_index));
+        new cuda_buffer_pinned_reader(shared_from_this(), buf_props, itemsize, _write_index));
     _readers.push_back(r.get());
     return r;
 }

--- a/runtime/lib/cudabuffer_sm.cu
+++ b/runtime/lib/cudabuffer_sm.cu
@@ -68,16 +68,6 @@ void* cuda_buffer_sm::write_ptr()
     }
 }
 
-// void cuda_buffer_sm_reader::post_read(int num_items)
-// {
-//     std::lock_guard<std::mutex> guard(_rdr_mutex);
-//     // advance the read pointer
-//     _read_index += num_items * _buffer->item_size();
-//     if (_read_index >= _buffer->buf_size()) {
-//         _read_index -= _buffer->buf_size();
-//     }
-//     _total_read += num_items;
-// }
 void cuda_buffer_sm::post_write(int num_items)
 {
     std::lock_guard<std::mutex> guard(_buf_mutex);
@@ -118,10 +108,10 @@ void cuda_buffer_sm::post_write(int num_items)
 }
 
 std::shared_ptr<buffer_reader>
-cuda_buffer_sm::add_reader(std::shared_ptr<buffer_properties> buf_props)
+cuda_buffer_sm::add_reader(std::shared_ptr<buffer_properties> buf_props, size_t itemsize)
 {
     std::shared_ptr<cuda_buffer_sm_reader> r(
-        new cuda_buffer_sm_reader(std::dynamic_pointer_cast<cuda_buffer_sm>(shared_from_this()), buf_props, _write_index));
+        new cuda_buffer_sm_reader(std::dynamic_pointer_cast<cuda_buffer_sm>(shared_from_this()), buf_props, itemsize, _write_index));
     _readers.push_back(r.get());
     return r;
 }

--- a/runtime/lib/graph.cc
+++ b/runtime/lib/graph.cc
@@ -11,7 +11,8 @@ edge_sptr graph::connect(const node_endpoint& src,
         std::stringstream msg;
         msg << "itemsize mismatch: " << src << " using " << src.port()->itemsize() << ", " << dst
             << " using " << dst.port()->itemsize();
-        throw std::invalid_argument(msg.str());
+        //throw std::invalid_argument(msg.str());
+        GR_LOG_WARN(_logger, msg.str());
     }
 
     // If not untyped ports, check that data types are the same

--- a/runtime/lib/simplebuffer.cc
+++ b/runtime/lib/simplebuffer.cc
@@ -2,10 +2,10 @@
 
 namespace gr
 {
-    std::shared_ptr<buffer_reader> simplebuffer::add_reader(std::shared_ptr<buffer_properties> buf_props)
+    std::shared_ptr<buffer_reader> simplebuffer::add_reader(std::shared_ptr<buffer_properties> buf_props, size_t itemsize)
     {
         std::shared_ptr<simplebuffer_reader> r(
-            new simplebuffer_reader(shared_from_this(), buf_props, _write_index));
+            new simplebuffer_reader(shared_from_this(), buf_props, itemsize, _write_index));
         _readers.push_back(r.get());
         return r;
     }

--- a/runtime/lib/vmcircbuf.cc
+++ b/runtime/lib/vmcircbuf.cc
@@ -70,7 +70,7 @@ void vmcirc_buffer_reader::post_read(int num_items)
     std::scoped_lock guard(_rdr_mutex);
 
     // advance the read pointer
-    _read_index += num_items * _buffer->item_size();
+    _read_index += num_items * _itemsize;
     if (_read_index >= _buffer->buf_size()) {
         _read_index -= _buffer->buf_size();
     }
@@ -91,10 +91,10 @@ void vmcirc_buffer::post_write(int num_items)
     _total_written += num_items;
 }
 
-std::shared_ptr<buffer_reader> vmcirc_buffer::add_reader(std::shared_ptr<buffer_properties> buf_props)
+std::shared_ptr<buffer_reader> vmcirc_buffer::add_reader(std::shared_ptr<buffer_properties> buf_props, size_t itemsize)
 {
     std::shared_ptr<vmcirc_buffer_reader> r(
-        new vmcirc_buffer_reader(shared_from_this(), buf_props, _write_index));
+        new vmcirc_buffer_reader(shared_from_this(), buf_props, itemsize, _write_index));
     _readers.push_back(r.get());
     return r;
 }

--- a/schedulers/mt/test/meson.build
+++ b/schedulers/mt/test/meson.build
@@ -71,6 +71,7 @@ if get_option('enable_testing')
     test('MT Tags Tests', e)
 
     test('Basic Python', find_program('qa_basic.py'), env: env)
+    test('Varying Vector Sizes', find_program('qa_mismatch.py'), env: env)
 
 endif
 

--- a/schedulers/mt/test/qa_mismatch.py
+++ b/schedulers/mt/test/qa_mismatch.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+from newsched import gr_unittest, gr, blocks
+from newsched.schedulers import mt
+
+class test_basic(gr_unittest.TestCase):
+
+    def setUp(self):
+        self.tb = gr.flowgraph()
+
+    def tearDown(self):
+        self.tb = None
+
+    def test_basic(self):
+        nsamples = 100000
+        input_data = list(range(nsamples))
+
+        limiting_factor = 32
+        max_expected1 = limiting_factor * (nsamples // limiting_factor)
+        limiting_factor = 64
+        max_expected2 = limiting_factor * (nsamples // limiting_factor)
+        expected_data1 = input_data[0:max_expected1]
+        expected_data1 = [pow(2.0,5.0)*x for x in expected_data1]
+        expected_data2 = input_data[0:max_expected2]
+        expected_data2 = [pow(2.0,5.0)*x for x in expected_data2]
+
+
+        src = blocks.vector_source_f(input_data, False)
+        mult1 = blocks.multiply_const_ff(2.0, 1)
+        mult2 = blocks.multiply_const_ff(2.0, 32)
+        mult3 = blocks.multiply_const_ff(2.0, 32)
+        mult4 = blocks.multiply_const_ff(2.0, 16)
+        mult5 = blocks.multiply_const_ff(2.0, 4)
+        mult6 = blocks.multiply_const_ff(2.0, 2)
+        mult7 = blocks.multiply_const_ff(2.0, 64)
+
+        snk1 = blocks.vector_sink_f()
+        snk2 = blocks.vector_sink_f()
+
+        self.tb.connect(src, 0, mult1, 0)
+        self.tb.connect(mult1, 0, mult2, 0)
+        self.tb.connect(mult2, 0, mult3, 0)
+        self.tb.connect(mult3, 0, mult4, 0)
+        self.tb.connect(mult3, 0, mult5, 0)
+        self.tb.connect(mult4, 0, mult6, 0)
+        self.tb.connect(mult5, 0, mult7, 0)
+        self.tb.connect(mult6, 0, snk1, 0)
+        self.tb.connect(mult7, 0, snk2, 0)
+
+        self.tb.start()
+        self.tb.wait()
+
+        self.assertFloatTuplesAlmostEqual(expected_data1, snk1.data())
+        self.assertFloatTuplesAlmostEqual(expected_data2, snk2.data())
+
+if __name__ == "__main__":
+    gr_unittest.run(test_basic)


### PR DESCRIPTION
By storing the item size of the destination port, we shouldn't need copying vector to stream, stream to vector type of conversion blocks.

Still needs some check mechanisms to ensure the ports are related (ie, don't want to connect an int to a float), but with this we should be able to connect "untyped" to any typed - doesn't matter the vector size, and then any vector size to any vector size of the same type within reason

Will need more logic to ensure the buffer is large enough for the vector size - since that might only be based on the buffer size, not the reader - perhaps throw an error if the reader is of a single item size > 1/2 the buffer


Addresses #67 