### PR TITLE
runtime: allow for 0 itemsize on blocks

### DIFF
--- a/blocklib/blocks/annotator/annotator.yml
+++ b/blocklib/blocks/annotator/annotator.yml
@@ -12,10 +12,6 @@ parameters:
     label: When
     dtype: uint64_t
     settable: false
--   id: itemsize
-    label: Item Size
-    dtype: size_t
-    settable: false
 -   id: num_inputs
     label: Num Inputs
     dtype: size_t
@@ -28,6 +24,13 @@ parameters:
     label: Tag Propagation Policy
     dtype: gr::tag_propagation_policy_t
     settable: false
+-   id: itemsize
+    label: Item Size
+    dtype: size_t
+    settable: false
+    default: 0
+    grc:
+        hide: all
 
 ports:
 -   domain: stream

--- a/blocklib/blocks/copy/copy.yml
+++ b/blocklib/blocks/copy/copy.yml
@@ -14,7 +14,9 @@ parameters:
       label: Item Size
       dtype: size_t
       settable: false
-
+      default: 0
+      grc:
+          hide: all
 ports:
     - domain: stream
       id: in

--- a/blocklib/blocks/copy/copy_cpu.cc
+++ b/blocklib/blocks/copy/copy_cpu.cc
@@ -7,7 +7,7 @@ work_return_code_t copy_cpu::work(std::vector<block_work_input>& work_input,
                                   std::vector<block_work_output>& work_output)
 {
     auto iptr = work_input[0].items<uint8_t>();
-    int size = work_output[0].n_items * d_itemsize;
+    int size = work_output[0].n_items * work_output[0].buffer->item_size();
     auto optr = work_output[0].items<uint8_t>();
     // std::copy(iptr, iptr + size, optr);
     memcpy(optr, iptr, size);

--- a/blocklib/blocks/delay/delay.yml
+++ b/blocklib/blocks/delay/delay.yml
@@ -4,14 +4,17 @@ label: Delay
 blocktype: block
 
 parameters:
--   id: itemsize
-    label: Item Size
-    dtype: size_t
-    settable: false
 -   id: dly
     label: Delay
     dtype: size_t
     settable: true
+-   id: itemsize
+    label: Item Size
+    dtype: size_t
+    settable: false
+    default: 0
+    grc:
+        hide: all
 
 ports:
 -   domain: stream

--- a/blocklib/blocks/delay/delay_cpu.cc
+++ b/blocklib/blocks/delay/delay_cpu.cc
@@ -27,6 +27,7 @@ work_return_code_t delay_cpu::work(std::vector<block_work_input>& work_input,
 {
     std::scoped_lock l(d_mutex);
     assert(work_input.size() == work_output.size());
+    auto itemsize = work_output[0].buffer->item_size();
 
     const uint8_t* iptr;
     uint8_t* optr;
@@ -39,7 +40,7 @@ work_return_code_t delay_cpu::work(std::vector<block_work_input>& work_input,
         for (size_t i = 0; i < work_input.size(); i++) {
             iptr = work_input[i].items<uint8_t>();
             optr = work_output[i].items<uint8_t>();
-            std::memcpy(optr, iptr, noutput_items * d_itemsize);
+            std::memcpy(optr, iptr, noutput_items * itemsize);
         }
         cons = noutput_items;
         ret = noutput_items;
@@ -54,7 +55,7 @@ work_return_code_t delay_cpu::work(std::vector<block_work_input>& work_input,
         for (size_t i = 0; i < work_input.size(); i++) {
             iptr = work_input[i].items<uint8_t>();
             optr = work_output[i].items<uint8_t>();
-            std::memcpy(optr, iptr + delta * d_itemsize, n_to_copy * d_itemsize);
+            std::memcpy(optr, iptr + delta * itemsize, n_to_copy * itemsize);
         }
         cons = noutput_items;
         ret = n_to_copy;
@@ -70,8 +71,8 @@ work_return_code_t delay_cpu::work(std::vector<block_work_input>& work_input,
         for (size_t i = 0; i < work_input.size(); i++) {
             iptr = work_input[i].items<uint8_t>();
             optr = work_output[i].items<uint8_t>();
-            std::memset(optr, 0, n_padding * d_itemsize);
-            std::memcpy(optr + n_padding * d_itemsize, iptr, n_from_input * d_itemsize);
+            std::memset(optr, 0, n_padding * itemsize);
+            std::memcpy(optr + n_padding * itemsize, iptr, n_from_input * itemsize);
         }
         cons = n_from_input;
         ret = noutput_items;

--- a/blocklib/blocks/head/head.yml
+++ b/blocklib/blocks/head/head.yml
@@ -4,14 +4,17 @@ label: Head
 blocktype: sync_block
 
 parameters:
--   id: itemsize
-    label: Item Size
-    dtype: size_t
-    settable: false
 -   id: nitems
     label: Num. Items
     dtype: size_t
     settable: false
+-   id: itemsize
+    label: Item Size
+    dtype: size_t
+    settable: false
+    default: 0
+    grc:
+        hide: all
 
 ports:
 -   domain: stream

--- a/blocklib/blocks/head/head_cpu.cc
+++ b/blocklib/blocks/head/head_cpu.cc
@@ -37,7 +37,7 @@ work_return_code_t head_cpu::work(std::vector<block_work_input>& work_input,
         return work_return_code_t::WORK_OK;
     }
 
-    memcpy(optr, iptr, n * d_itemsize);
+    memcpy(optr, iptr, n * work_input[0].buffer->item_size());
 
     d_ncopied_items += n;
     work_output[0].n_produced = n;

--- a/blocklib/blocks/load/load.yml
+++ b/blocklib/blocks/load/load.yml
@@ -4,15 +4,17 @@ label: Load
 blocktype: sync_block
 
 parameters:
--   id: itemsize
-    label: Item Size
-    dtype: size_t
-    settable: false
 -   id: iterations
     label: Iterations (Load)
     dtype: size_t
     settable: true
-
+-   id: itemsize
+    label: Item Size
+    dtype: size_t
+    settable: false
+    default: 0
+    grc:
+        hide: all
 ports:
 -   domain: stream
     id: in

--- a/blocklib/blocks/nop/nop.yml
+++ b/blocklib/blocks/nop/nop.yml
@@ -8,6 +8,9 @@ parameters:
     label: Item Size
     dtype: size_t
     settable: false
+    default: 0
+    grc:
+        hide: all
 
 ports:
 -   domain: stream

--- a/blocklib/blocks/nop_head/nop_head.yml
+++ b/blocklib/blocks/nop_head/nop_head.yml
@@ -4,15 +4,17 @@ label: Nop Head
 blocktype: sync_block
 
 parameters:
--   id: itemsize
-    label: Item Size
-    dtype: size_t
-    settable: false
 -   id: nitems
     label: Num. Items
     dtype: size_t
     settable: false
-
+-   id: itemsize
+    label: Item Size
+    dtype: size_t
+    settable: false
+    default: 0
+    grc:
+        hide: all
 ports:
 -   domain: stream
     id: in

--- a/blocklib/blocks/nop_source/nop_source.yml
+++ b/blocklib/blocks/nop_source/nop_source.yml
@@ -4,16 +4,19 @@ label: Nop Source
 blocktype: sync_block
 
 parameters:
--   id: itemsize
-    label: Item Size
-    dtype: size_t
-    settable: false
 -   id: nports
     label: Num. Ports
     dtype: size_t
     default: 1
     settable: false
-
+-   id: itemsize
+    label: Item Size
+    dtype: size_t
+    settable: false
+    default: 0
+    grc:
+        hide: all
+        
 ports:
 -   domain: stream
     id: out

--- a/blocklib/blocks/null_sink/null_sink.yml
+++ b/blocklib/blocks/null_sink/null_sink.yml
@@ -4,16 +4,18 @@ label: Null Sink
 blocktype: sync_block
 
 parameters:
--   id: itemsize
-    label: Item Size
-    dtype: size_t
-    settable: false
 -   id: nports
     label: Num. Ports
     dtype: size_t
     default: 1
     settable: false
-
+-   id: itemsize
+    label: Item Size
+    dtype: size_t
+    settable: false
+    default: 0
+    grc:
+        hide: all
 ports:
 -   domain: stream
     id: in

--- a/blocklib/blocks/null_source/null_source.yml
+++ b/blocklib/blocks/null_source/null_source.yml
@@ -4,16 +4,19 @@ label: Null Source
 blocktype: sync_block
 
 parameters:
--   id: itemsize
-    label: Item Size
-    dtype: size_t
-    settable: false
 -   id: nports
     label: Num. Ports
     dtype: size_t
     default: 1
     settable: false
-
+-   id: itemsize
+    label: Item Size
+    dtype: size_t
+    settable: false
+    default: 0
+    grc:
+        hide: all
+        
 ports:
 -   domain: stream
     id: out

--- a/blocklib/blocks/test/qa_delay.py
+++ b/blocklib/blocks/test/qa_delay.py
@@ -28,7 +28,7 @@ class test_delay(gr_unittest.TestCase):
         expected_result = list(delta_t * [0.0] + src_data)
 
         src = blocks.vector_source_f(src_data)
-        op = blocks.delay(gr.sizeof_float, delta_t)
+        op = blocks.delay(delta_t)
         dst = blocks.vector_sink_f()
 
         tb.connect(src, op)
@@ -44,7 +44,7 @@ class test_delay(gr_unittest.TestCase):
         expected_result = list(delta_t * [0.0] + src_data)
 
         src = blocks.vector_source_f(src_data)
-        op = blocks.delay(gr.sizeof_float, delta_t)
+        op = blocks.delay(delta_t)
         dst = blocks.vector_sink_f()
 
         tb.connect(src, op)

--- a/blocklib/blocks/throttle/throttle.yml
+++ b/blocklib/blocks/throttle/throttle.yml
@@ -4,10 +4,6 @@ label: throttle
 blocktype: sync_block
 
 parameters:
--   id: itemsize
-    label: Item Size
-    dtype: size_t
-    settable: false
 -   id: samples_per_sec
     label: Samples Per Second
     dtype: double
@@ -17,7 +13,14 @@ parameters:
     dtype: bool
     settable: false
     default: 'true'
-
+-   id: itemsize
+    label: Item Size
+    dtype: size_t
+    settable: false
+    default: 0
+    grc:
+        hide: all
+        
 ports:
 -   domain: stream
     id: in

--- a/blocklib/blocks/throttle/throttle_cpu.cc
+++ b/blocklib/blocks/throttle/throttle_cpu.cc
@@ -75,7 +75,7 @@ work_return_code_t throttle_cpu::work(std::vector<block_work_input>& work_input,
 
     // TODO: blocks like throttle shouldn't need to do a memcpy, but this would have to be
     // fixed in the buffering model and a special port type
-    std::memcpy(out, in, n * d_itemsize);
+    std::memcpy(out, in, n * work_output[0].buffer->item_size());
     work_output[0].n_produced = n;
     return work_return_code_t::WORK_OK;
 }

--- a/blocklib/blocks/vector_sink/vector_sink.yml
+++ b/blocklib/blocks/vector_sink/vector_sink.yml
@@ -45,6 +45,8 @@ parameters:
     container: vector
     gettable: true
     cotr: false
+    grc:
+      hide: all
 # callbacks:
 # -   id: data
 #     return: std::vector<T>

--- a/blocklib/streamops/stream_to_streams/stream_to_streams.yml
+++ b/blocklib/streamops/stream_to_streams/stream_to_streams.yml
@@ -4,15 +4,18 @@ label: Stream To Streams
 blocktype: block
 
 parameters:
--   id: itemsize
-    label: Item Size
-    dtype: size_t
-    settable: false
 -   id: nstreams
     label: Number of Streams
     dtype: size_t
     settable: false
-
+-   id: itemsize
+    label: Item Size
+    dtype: size_t
+    settable: false
+    default: 0
+    grc:
+        hide: all
+        
 ports:
 -   domain: stream
     id: in

--- a/runtime/include/gnuradio/port.hh
+++ b/runtime/include/gnuradio/port.hh
@@ -20,6 +20,8 @@ enum class port_direction_t {
     BIDIRECTONAL //?? can it be done
 };
 
+class block;
+
 /**
  * @brief Base class for all ports
  *
@@ -98,6 +100,7 @@ public:
     port_direction_t direction() { return _direction; }
     size_t data_size() { return _datasize; }
     size_t itemsize() { return _itemsize; }
+    void set_itemsize(size_t itemsize) { _itemsize = itemsize; }
     std::vector<size_t> dims() { return _dims; }
     sptr base() { return shared_from_this(); }
     bool optional() { return _optional; }
@@ -163,6 +166,8 @@ protected:
     neighbor_interface_sptr _parent_intf = nullptr;
     buffer_sptr _buffer = nullptr;
     buffer_reader_sptr _buffer_reader = nullptr;
+
+    block *_parent_block = nullptr;
 };
 
 typedef port_base::sptr port_sptr;

--- a/runtime/lib/graph.cc
+++ b/runtime/lib/graph.cc
@@ -6,7 +6,7 @@ edge_sptr graph::connect(const node_endpoint& src,
                     const node_endpoint& dst)
 {
     
-    if (src.port()->itemsize() != dst.port()->itemsize())
+    if (src.port()->itemsize() != dst.port()->itemsize() && src.port()->itemsize() > 0 && dst.port()->itemsize() > 0 )
     {
         std::stringstream msg;
         msg << "itemsize mismatch: " << src << " using " << src.port()->itemsize() << ", " << dst

--- a/schedulers/nbt/test/qa_parameters.py
+++ b/schedulers/nbt/test/qa_parameters.py
@@ -15,7 +15,7 @@ class test_basic(gr_unittest.TestCase):
         run_time = 1
 
         src = blocks.vector_source_f([1,2,3,4,5],True)
-        throttle = blocks.throttle(gr.sizeof_float, 32000)
+        throttle = blocks.throttle(32000)
         mult1 = math.multiply_const_ff(100.0)
         snk1 = blocks.vector_sink_f()
         snk2 = blocks.vector_sink_f()

--- a/schedulers/nbt/test/qa_tags.cc
+++ b/schedulers/nbt/test/qa_tags.cc
@@ -20,16 +20,16 @@ TEST(SchedulerMTTags, OneToOne)
 {
     size_t N = 40000;
     auto fg = flowgraph::make();
-    auto src = gr::blocks::null_source::make({sizeof(int)});
-    auto head = gr::blocks::head::make_cpu({sizeof(int), N});
+    auto src = gr::blocks::null_source::make({});
+    auto head = gr::blocks::head::make_cpu({N});
     auto ann0 = gr::blocks::annotator::make_cpu(
-        {10000, sizeof(int), 1, 2, tag_propagation_policy_t::TPP_ONE_TO_ONE});
+        {10000, 1, 2, tag_propagation_policy_t::TPP_ONE_TO_ONE});
     auto ann1 = gr::blocks::annotator::make_cpu(
-        {10000, sizeof(int), 1, 1, tag_propagation_policy_t::TPP_ONE_TO_ONE});
+        {10000, 1, 1, tag_propagation_policy_t::TPP_ONE_TO_ONE});
     auto ann2 = gr::blocks::annotator::make_cpu(
-        {10000, sizeof(int), 1, 1, tag_propagation_policy_t::TPP_ONE_TO_ONE});
-    auto snk0 = gr::blocks::null_sink::make({sizeof(int)});
-    auto snk1 = gr::blocks::null_sink::make({sizeof(int)});
+        {10000, 1, 1, tag_propagation_policy_t::TPP_ONE_TO_ONE});
+    auto snk0 = gr::blocks::null_sink::make({});
+    auto snk1 = gr::blocks::null_sink::make({});
 
     // using 1-to-1 tag propagation without having equal number of
     // ins and outs. Make sure this works; will just exit run early.
@@ -66,21 +66,21 @@ TEST(SchedulerMTTags, t1)
 {
     size_t N = 40000;
     auto fg = flowgraph::make();
-    auto src = gr::blocks::null_source::make({sizeof(int)});
-    auto head = gr::blocks::head::make_cpu({sizeof(int), N});
+    auto src = gr::blocks::null_source::make({});
+    auto head = gr::blocks::head::make_cpu({N});
     auto ann0 = gr::blocks::annotator::make_cpu(
-        {10000, sizeof(int), 1, 2, tag_propagation_policy_t::TPP_ALL_TO_ALL});
+        {10000, 1, 2, tag_propagation_policy_t::TPP_ALL_TO_ALL});
     auto ann1 = gr::blocks::annotator::make_cpu(
-        {10000, sizeof(int), 1, 1, tag_propagation_policy_t::TPP_ALL_TO_ALL});
+        {10000, 1, 1, tag_propagation_policy_t::TPP_ALL_TO_ALL});
     auto ann2 = gr::blocks::annotator::make_cpu(
-        {10000, sizeof(int), 1, 1, tag_propagation_policy_t::TPP_ALL_TO_ALL});
+        {10000, 1, 1, tag_propagation_policy_t::TPP_ALL_TO_ALL});
     auto ann3 = gr::blocks::annotator::make_cpu(
-        {10000, sizeof(int), 1, 1, tag_propagation_policy_t::TPP_ALL_TO_ALL});
+        {10000, 1, 1, tag_propagation_policy_t::TPP_ALL_TO_ALL});
     auto ann4 = gr::blocks::annotator::make_cpu(
-        {10000, sizeof(int), 1, 1, tag_propagation_policy_t::TPP_ALL_TO_ALL});
+        {10000, 1, 1, tag_propagation_policy_t::TPP_ALL_TO_ALL});
 
-    auto snk0 = gr::blocks::null_sink::make({sizeof(int)});
-    auto snk1 = gr::blocks::null_sink::make({sizeof(int)});
+    auto snk0 = gr::blocks::null_sink::make({});
+    auto snk1 = gr::blocks::null_sink::make({});
 
     fg->connect(src, 0, head, 0);
     fg->connect(head, 0, ann0, 0);
@@ -113,21 +113,21 @@ TEST(SchedulerMTTags,t2)
 {
     size_t N = 40000;
     auto fg = flowgraph::make();
-    auto src = gr::blocks::null_source::make({sizeof(int)});
-    auto head = gr::blocks::head::make_cpu({sizeof(int), N});
+    auto src = gr::blocks::null_source::make({});
+    auto head = gr::blocks::head::make_cpu({N});
     auto ann0 = gr::blocks::annotator::make_cpu(
-        {10000, sizeof(int), 1, 2, tag_propagation_policy_t::TPP_ALL_TO_ALL});
+        {10000, 1, 2, tag_propagation_policy_t::TPP_ALL_TO_ALL});
     auto ann1 = gr::blocks::annotator::make_cpu(
-        {10000, sizeof(int), 2, 3, tag_propagation_policy_t::TPP_ALL_TO_ALL});
+        {10000, 2, 3, tag_propagation_policy_t::TPP_ALL_TO_ALL});
     auto ann2 = gr::blocks::annotator::make_cpu(
-        {10000, sizeof(int), 1, 1, tag_propagation_policy_t::TPP_ALL_TO_ALL});
+        {10000, 1, 1, tag_propagation_policy_t::TPP_ALL_TO_ALL});
     auto ann3 = gr::blocks::annotator::make_cpu(
-        {10000, sizeof(int), 1, 1, tag_propagation_policy_t::TPP_ALL_TO_ALL});
+        {10000, 1, 1, tag_propagation_policy_t::TPP_ALL_TO_ALL});
     auto ann4 = gr::blocks::annotator::make_cpu(
-        {10000, sizeof(int), 1, 1, tag_propagation_policy_t::TPP_ALL_TO_ALL});
-    auto snk0 = gr::blocks::null_sink::make({sizeof(int)});
-    auto snk1 = gr::blocks::null_sink::make({sizeof(int)});
-    auto snk2 = gr::blocks::null_sink::make({sizeof(int)});
+        {10000, 1, 1, tag_propagation_policy_t::TPP_ALL_TO_ALL});
+    auto snk0 = gr::blocks::null_sink::make({});
+    auto snk1 = gr::blocks::null_sink::make({});
+    auto snk2 = gr::blocks::null_sink::make({});
 
     fg->connect(src, 0, head, 0);
     fg->connect(head, 0, ann0, 0);
@@ -170,20 +170,20 @@ TEST(SchedulerMTTags, t3)
 {
     size_t N = 40000;
     auto fg = flowgraph::make();
-    auto src = gr::blocks::null_source::make({sizeof(int)});
-    auto head = gr::blocks::head::make_cpu({sizeof(int), N});
+    auto src = gr::blocks::null_source::make({});
+    auto head = gr::blocks::head::make_cpu({N});
     auto ann0 = gr::blocks::annotator::make_cpu(
-        {10000, sizeof(int), 2, 2, tag_propagation_policy_t::TPP_ONE_TO_ONE});
+        {10000, 2, 2, tag_propagation_policy_t::TPP_ONE_TO_ONE});
     auto ann1 = gr::blocks::annotator::make_cpu(
-        {10000, sizeof(int), 1, 1, tag_propagation_policy_t::TPP_ALL_TO_ALL});
+        {10000, 1, 1, tag_propagation_policy_t::TPP_ALL_TO_ALL});
     auto ann2 = gr::blocks::annotator::make_cpu(
-        {10000, sizeof(int), 1, 1, tag_propagation_policy_t::TPP_ALL_TO_ALL});
+        {10000, 1, 1, tag_propagation_policy_t::TPP_ALL_TO_ALL});
     auto ann3 = gr::blocks::annotator::make_cpu(
-        {10000, sizeof(int), 1, 1, tag_propagation_policy_t::TPP_ONE_TO_ONE});
+        {10000, 1, 1, tag_propagation_policy_t::TPP_ONE_TO_ONE});
     auto ann4 = gr::blocks::annotator::make_cpu(
-        {10000, sizeof(int), 1, 1, tag_propagation_policy_t::TPP_ONE_TO_ONE});
-    auto snk0 = gr::blocks::null_sink::make({sizeof(int)});
-    auto snk1 = gr::blocks::null_sink::make({sizeof(int)});
+        {10000, 1, 1, tag_propagation_policy_t::TPP_ONE_TO_ONE});
+    auto snk0 = gr::blocks::null_sink::make({});
+    auto snk1 = gr::blocks::null_sink::make({});
 
     fg->connect(src, 0, head, 0);
     fg->connect(head, 0, ann0, 0);
@@ -227,11 +227,11 @@ TEST(SchedulerMTTags, t5)
     auto src = gr::blocks::null_source::make({sizeof(int)});
     auto head = gr::blocks::head::make_cpu(sizeof(int), N);
     auto ann0 = gr::blocks::annotator::make_cpu(
-        10000, sizeof(int), 1, 2, tag_propagation_policy_t::TPP_ALL_TO_ALL);
+        10000, 1, 2, tag_propagation_policy_t::TPP_ALL_TO_ALL);
     auto ann1 = gr::blocks::annotator::make_cpu(
-        10000, sizeof(int), 1, 1, tag_propagation_policy_t::TPP_ALL_TO_ALL);
+        10000, 1, 1, tag_propagation_policy_t::TPP_ALL_TO_ALL);
     auto ann2 = gr::blocks::annotator::make_cpu(
-        10000, sizeof(int), 1, 1, tag_propagation_policy_t::TPP_ALL_TO_ALL);
+        10000, 1, 1, tag_propagation_policy_t::TPP_ALL_TO_ALL);
     auto snk0 = gr::blocks::null_sink::make(sizeof(int));
 
     // Rate change blocks

--- a/utils/blockbuilder/templates/blockname.grc.j2
+++ b/utils/blockbuilder/templates/blockname.grc.j2
@@ -36,13 +36,12 @@ parameters:
 {% endfor %}
 {% endif -%}
 {% for param in parameters -%}
-{% if 'grc' not in param or ('hide' in param['grc'] and param['grc']['hide'] != 'all') -%}
+{#{% if 'grc' not in param or ('hide' in param['grc'] and param['grc']['hide'] != 'all') -%}#}
 -   id: {{param['id']}}
     label: {{param['label']}}
     dtype: {{type_lookup(param['dtype'],'raw')}}
     default: {%if 'grc' in param and 'default' in param['grc']%}{{param['grc']['default']}}{%elif 'default' in param %}{{param['default']}}{%endif%}
     {%if 'grc' in param and 'hide' in param['grc']%}hide: {{param['grc']['hide']}}{%endif%}
-{%endif-%}
 {% endfor -%}
 {% if grc and 'parameters' in grc -%}
 {% for param in grc['parameters'] -%}

--- a/utils/modtool/newblock/newblock.yml
+++ b/utils/modtool/newblock/newblock.yml
@@ -8,6 +8,10 @@ parameters:
 -   id: itemsize
     label: Item Size
     dtype: size_t
+    settable: false
+    default: 0
+    grc:
+        hide: all
 
 # Exampler Ports
 ports:


### PR DESCRIPTION
Automatically infer what the size should be in this case from whatever
it is connected to.

Move the itemsize parameter to the end with default 0

Signed-off-by: Josh Morman <jmorman@gnuradio.org>