### PR TITLE
runtime: zmq custom buffer

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -51,6 +51,8 @@ if USE_CUDA
 cusp_dep = dependency('cusp', version : '>=0.0.1', required : USE_CUDA) 
 endif
 
+zmq_dep = dependency('libzmq', required : true)
+
 # pmtf_dep = dependency('pmtf', version : '>=0.0.2')
 libpmtf = subproject('pmt')
 pmtf_dep = libpmtf.get_variable('pmtf_dep')

--- a/runtime/include/gnuradio/buffer.hh
+++ b/runtime/include/gnuradio/buffer.hh
@@ -7,6 +7,8 @@
 #include <mutex>
 #include <vector>
 #include <gnuradio/logging.hh>
+#include <gnuradio/neighbor_interface.hh>
+
 namespace gr {
 
 /**
@@ -33,6 +35,9 @@ typedef std::function<std::shared_ptr<buffer>(
     size_t, size_t, std::shared_ptr<buffer_properties>)>
     buffer_factory_function;
 
+typedef std::function<std::shared_ptr<buffer_reader>(
+    size_t, std::shared_ptr<buffer_properties>)>
+    buffer_reader_factory_function;
 
 /**
  * @brief Base class for passing custom buffer properties into factory method
@@ -89,6 +94,9 @@ public:
         return shared_from_this();
     }
     buffer_factory_function factory() { return _bff; }
+    buffer_reader_factory_function reader_factory() { return _brff; }
+
+    auto independent_reader() { return _independent_reader; }
 
 protected:
     size_t _buffer_size = 0;
@@ -100,6 +108,9 @@ protected:
     size_t _min_buffer_read = 0;
 
     buffer_factory_function _bff = nullptr;
+    buffer_reader_factory_function _brff = nullptr;
+
+    bool _independent_reader = false;
 };
 
 /**
@@ -276,7 +287,7 @@ public:
     virtual ~buffer_reader() {}
     size_t read_index() { return _read_index; }
     void set_read_index(size_t r) { _read_index = r; }
-    void* read_ptr() { return _buffer->read_ptr(_read_index); }
+    virtual void* read_ptr() { return _buffer->read_ptr(_read_index); }
     virtual void post_read(int num_items) = 0;
     uint64_t total_read() const { return _total_read; }
     // std::shared_ptr<buffer_properties>& buf_properties() { return _buf_properties; }
@@ -326,9 +337,17 @@ public:
      * items
      * @return std::vector<tag_t> Returns the vector of tags
      */
-    std::vector<tag_t> get_tags(size_t num_items);
+    virtual std::vector<tag_t> get_tags(size_t num_items);
 
-    const std::vector<tag_t>& tags() const;
+    virtual const std::vector<tag_t>& tags() const;
+
+    void set_parent_intf(neighbor_interface_sptr sched) { p_scheduler = sched; }
+    void notify_scheduler();
+    void notify_scheduler_input();
+    void notify_scheduler_output();
+
+protected:
+    neighbor_interface_sptr p_scheduler = nullptr;
 };
 
 } // namespace gr

--- a/runtime/include/gnuradio/buffer_cpu_vmcirc.hh
+++ b/runtime/include/gnuradio/buffer_cpu_vmcirc.hh
@@ -37,7 +37,9 @@ public:
 
     // These methods are common to all the vmcircbufs
 
-    void* read_ptr(size_t index) { return (void*)&_buffer[index]; }
+    void* read_ptr(size_t index) { 
+        return (void*)&_buffer[index]; 
+    }
     void* write_ptr();
 
     // virtual void post_read(int num_items);

--- a/runtime/include/gnuradio/buffer_management.hh
+++ b/runtime/include/gnuradio/buffer_management.hh
@@ -3,6 +3,7 @@
 #include <gnuradio/api.h>
 #include <gnuradio/flat_graph.hh>
 #include <gnuradio/logging.hh>
+#include <gnuradio/neighbor_interface.hh>
 
 namespace gr {
 
@@ -28,7 +29,8 @@ public:
     ~buffer_manager() {}
 
     void initialize_buffers(flat_graph_sptr fg,
-                            std::shared_ptr<buffer_properties> buf_props);
+                            std::shared_ptr<buffer_properties> buf_props,
+                            neighbor_interface_sptr sched_intf = nullptr);
 
 private:
     int get_buffer_num_items(edge_sptr e, flat_graph_sptr fg);

--- a/runtime/include/gnuradio/buffer_net_zmq.hh
+++ b/runtime/include/gnuradio/buffer_net_zmq.hh
@@ -1,0 +1,138 @@
+#pragma once
+
+#include <string.h>
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include <zmq.hpp>
+
+#include <gnuradio/buffer.hh>
+
+namespace gr {
+
+
+class buffer_net_zmq_reader;
+
+class buffer_net_zmq : public buffer
+{
+private:
+    std::vector<uint8_t> _buffer;
+
+    zmq::context_t _context;
+    zmq::socket_t _socket;
+
+
+
+public:
+    typedef std::shared_ptr<buffer_net_zmq> sptr;
+    buffer_net_zmq(size_t num_items,
+                   size_t item_size,
+                   std::shared_ptr<buffer_properties> buffer_properties,
+                   int port);
+    virtual ~buffer_net_zmq(){};
+    static buffer_sptr make(size_t num_items,
+                            size_t item_size,
+                            std::shared_ptr<buffer_properties> buffer_properties);
+
+    void* read_ptr(size_t index) {
+        return nullptr;
+    }
+    virtual size_t space_available() override
+    {
+        return _num_items;
+    }
+    virtual void* write_ptr() override {
+        return _buffer.data();
+    }
+
+    virtual void post_write(int num_items) override {
+        // send the data from buffer over the socket
+        GR_LOG_DEBUG(_debug_logger, "sending {} items", num_items);
+        auto res = _socket.send(zmq::buffer(write_ptr(), num_items * _item_size), zmq::send_flags::none);
+        GR_LOG_DEBUG(_debug_logger, "send returned code {}", *res);
+    }
+
+    virtual std::shared_ptr<buffer_reader>
+    add_reader(std::shared_ptr<buffer_properties> buf_props, size_t itemsize) override
+    {
+        // do nothing because readers will be added on zmq connect
+        return nullptr;
+    }
+};
+
+class buffer_net_zmq_reader : public buffer_reader
+{
+private:
+    zmq::context_t _context;
+    zmq::socket_t _socket;  
+    zmq::message_t _msg;
+    size_t _msg_idx = 0;
+    size_t _msg_size = 0;
+
+    // Circular buffer for zmq to write into
+    gr::buffer_sptr _circbuf;
+    gr::buffer_reader_sptr _circbuf_rdr;
+
+    logger_sptr _logger;
+    logger_sptr _debug_logger;
+
+public:
+    bool _recv_done = false;
+    static buffer_reader_sptr make(size_t itemsize,
+                                   std::shared_ptr<buffer_properties> buf_props);
+    buffer_net_zmq_reader(
+                          std::shared_ptr<buffer_properties> buf_props,
+                          size_t itemsize,
+                                   const std::string& ipaddr,
+                                   int port);
+
+    virtual ~buffer_net_zmq_reader(){};
+
+    virtual bool read_info(buffer_info_t& info) { 
+        auto ret = _circbuf_rdr->read_info(info);
+        return  ret;
+
+    }
+    void* read_ptr() { 
+        return _circbuf_rdr->read_ptr(); 
+    }
+
+    // Tags not supported yet
+    const std::vector<tag_t>& tags() const override { return _circbuf->tags(); }
+    std::vector<tag_t> get_tags(size_t num_items) { return {}; }
+    virtual void post_read(int num_items) {
+        GR_LOG_DEBUG(_debug_logger, "post_read: {}", num_items);
+        _circbuf_rdr->post_read(num_items);
+    }
+};
+
+
+class buffer_net_zmq_properties : public buffer_properties
+{
+public:
+    // typedef sptr std::shared_ptr<buffer_properties>;
+    buffer_net_zmq_properties(const std::string& ipaddr, int port)
+        : buffer_properties(), _ipaddr(ipaddr), _port(port)
+    {
+        _bff = buffer_net_zmq::make;
+        _brff = buffer_net_zmq_reader::make;
+    }
+    virtual ~buffer_net_zmq_properties(){};
+
+    static std::shared_ptr<buffer_properties> make(const std::string& ipaddr, int port)
+    {
+        return std::dynamic_pointer_cast<buffer_properties>(
+            std::make_shared<buffer_net_zmq_properties>(ipaddr, port));
+    }
+
+    auto port() { return _port; }
+    auto ipaddr() { return _ipaddr; }
+
+private:
+    std::string _ipaddr;
+    int _port;
+};
+
+} // namespace gr

--- a/runtime/include/gnuradio/domain.hh
+++ b/runtime/include/gnuradio/domain.hh
@@ -2,12 +2,34 @@
 
 #include <iostream>
 #include <memory>
+#include <string>
 
 #include <gnuradio/block.hh>
 #include <gnuradio/graph.hh>
 #include <gnuradio/scheduler.hh>
 
 namespace gr {
+
+
+class execution_host_properties
+{
+    // Later break this out into dynamic classes
+    std::string _ipaddr;
+    int _port;
+
+    public:
+    execution_host_properties(const std::string& ipaddr, int port) : 
+    _ipaddr(ipaddr), _port(port)
+    {
+
+    }
+
+    static std::shared_ptr<execution_host_properties> make(const std::string& ipaddr, int port)
+    {
+        return std::make_shared<execution_host_properties>(ipaddr, port);
+    }
+};
+typedef std::shared_ptr<execution_host_properties> execution_host_properties_sptr;
 
 /**
  * @brief Domain Configuration
@@ -21,7 +43,8 @@ class domain_conf
 {
 public:
     domain_conf(scheduler_sptr sched,
-                std::vector<node_sptr> blocks)
+                std::vector<node_sptr> blocks,
+                execution_host_properties_sptr host = nullptr)
         : _sched(sched), _blocks(blocks)
     {
     }

--- a/runtime/include/gnuradio/edge.hh
+++ b/runtime/include/gnuradio/edge.hh
@@ -101,6 +101,7 @@ public:
 
     bool has_custom_buffer();
     buffer_factory_function buffer_factory();
+    buffer_reader_factory_function buffer_reader_factory();
     std::shared_ptr<buffer_properties> buf_properties();
 };
 

--- a/runtime/lib/buffer.cc
+++ b/runtime/lib/buffer.cc
@@ -198,4 +198,29 @@ const std::vector<tag_t>& buffer_reader::tags() const
 }
 
 
+void buffer_reader::notify_scheduler()
+{
+    if (p_scheduler) {
+        this->p_scheduler->push_message(
+            std::make_shared<scheduler_action>(scheduler_action_t::NOTIFY_ALL));
+    }
+}
+
+void buffer_reader::notify_scheduler_input()
+{
+    if (p_scheduler) {
+        this->p_scheduler->push_message(
+            std::make_shared<scheduler_action>(scheduler_action_t::NOTIFY_INPUT));
+    }
+}
+
+void buffer_reader::notify_scheduler_output()
+{
+    if (p_scheduler) {
+        this->p_scheduler->push_message(
+            std::make_shared<scheduler_action>(scheduler_action_t::NOTIFY_OUTPUT));
+    }
+}
+
+
 } // namespace gr

--- a/runtime/lib/buffer_net_zmq.cc
+++ b/runtime/lib/buffer_net_zmq.cc
@@ -1,0 +1,157 @@
+#include <gnuradio/buffer_cpu_vmcirc.hh>
+#include <gnuradio/buffer_net_zmq.hh>
+#include <thread>
+#include <chrono>
+
+namespace gr {
+
+buffer_sptr buffer_net_zmq::make(size_t num_items,
+                                 size_t item_size,
+                                 std::shared_ptr<buffer_properties> buffer_properties)
+{
+
+    auto zbp = std::static_pointer_cast<buffer_net_zmq_properties>(buffer_properties);
+    if (zbp != nullptr) {
+        return buffer_sptr(
+            new buffer_net_zmq(num_items, item_size, buffer_properties, zbp->port()));
+    } else {
+        throw std::runtime_error(
+            "Failed to cast buffer properties to buffer_net_zmq_properties");
+    }
+}
+
+buffer_net_zmq::buffer_net_zmq(size_t num_items,
+                               size_t item_size,
+                               std::shared_ptr<buffer_properties> buf_properties,
+                               int port)
+    : buffer(num_items, item_size, buf_properties),
+      _context(1),
+      _socket(_context, zmq::socket_type::push)
+{
+    _debug_logger = logging::get_logger("buffer_net_zmq", "debug");
+    set_type("buffer_net_zmq");
+    _buffer.resize(_buf_size);
+    int sndhwm = 1;
+    int rcvhwm = 1;
+    _socket.setsockopt(ZMQ_SNDHWM, &sndhwm, sizeof(sndhwm));
+    _socket.setsockopt(ZMQ_RCVHWM, &rcvhwm, sizeof(rcvhwm));
+    std::string endpoint = "tcp://*:" + std::to_string(port);
+    std::cout << "snd_endpoint: " << endpoint << std::endl;
+    _socket.bind(endpoint);
+}
+
+
+/****************************************************************************/
+/*   READER METHODS                                                         */
+/****************************************************************************/
+
+
+buffer_reader_sptr
+buffer_net_zmq_reader::make(size_t itemsize, std::shared_ptr<buffer_properties> buf_props)
+{
+    auto zbp = std::static_pointer_cast<buffer_net_zmq_properties>(buf_props);
+    if (zbp != nullptr) {
+        return buffer_reader_sptr(
+            new buffer_net_zmq_reader(buf_props, itemsize, zbp->ipaddr(), zbp->port()));
+    } else {
+        throw std::runtime_error(
+            "Failed to cast buffer properties to buffer_net_zmq_properties");
+    }
+}
+
+buffer_net_zmq_reader::buffer_net_zmq_reader(std::shared_ptr<buffer_properties> buf_props,
+                                             size_t itemsize,
+                                             const std::string& ipaddr,
+                                             int port)
+    : buffer_reader(nullptr, buf_props, itemsize, 0),
+      _context(1),
+      _socket(_context, zmq::socket_type::pull)
+{
+    _debug_logger = logging::get_logger("buffer_net_zmq_reader", "debug");
+    auto bufprops = std::make_shared<buffer_cpu_vmcirc_properties>();
+    _circbuf = gr::buffer_cpu_vmcirc::make(
+        8192,
+        itemsize,
+        bufprops); // FIXME - make nitems a buffer reader factory parameter
+    _circbuf_rdr = _circbuf->add_reader(bufprops, itemsize);
+
+    // auto b = (float *)_circbuf->write_ptr();
+    
+    // for (int i=0; i<8192; i++)
+    // {
+    //     b[i] = i;
+    // }
+    // _circbuf->post_write(8192);
+
+    // buffer_info_t info;
+    // _circbuf_rdr->read_info(info); 
+    // auto br = (float *)_circbuf_rdr->read_ptr();
+    
+
+    // _circbuf_rdr->post_read(4096);
+    // br = (float *) _circbuf_rdr->read_ptr();
+    
+
+    std::string endpoint = "tcp://" + ipaddr + ":" + std::to_string(port);
+    GR_LOG_DEBUG(_debug_logger, "rcv_endpoint: {}", endpoint);
+    int sndhwm = 1;
+    int rcvhwm = 1;
+    _socket.setsockopt(ZMQ_SNDHWM, &sndhwm, sizeof(sndhwm));
+    _socket.setsockopt(ZMQ_RCVHWM, &rcvhwm, sizeof(rcvhwm));
+    // _socket.setsockopt(ZMQ_SUBSCRIBE, "", 0);
+    _socket.connect(endpoint);
+    GR_LOG_DEBUG(_debug_logger, "   ... connected");
+
+    std::thread t([this]() {
+        while (!this->_recv_done) {
+            // zmq::message_t msg{};
+            // See how much room we have in the circular buffer
+            buffer_info_t wi;
+            _circbuf->write_info(wi);
+
+            auto n_bytes_left_in_msg = _msg.size() - _msg_idx;
+            auto n_bytes_in_circbuf = wi.n_items * wi.item_size;
+            auto bytes_to_write = std::min(n_bytes_in_circbuf, n_bytes_left_in_msg);
+            auto items_to_write = bytes_to_write / wi.item_size;
+            bytes_to_write = items_to_write * wi.item_size;
+
+            if (n_bytes_in_circbuf <= 0) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                continue;
+            }
+
+            if (bytes_to_write > 0)
+            {
+                memcpy(wi.ptr, _msg.data() + _msg_idx, bytes_to_write);
+                _msg_idx += bytes_to_write;
+                n_bytes_left_in_msg = _msg.size() - _msg_idx;
+                _circbuf->post_write(items_to_write);
+                notify_scheduler();
+            }
+
+            if (n_bytes_left_in_msg == 0)
+            {
+                _msg.rebuild();
+                _socket.recv(_msg, zmq::recv_flags::none);
+                _msg_idx = 0;
+            }
+            // GR_LOG_DEBUG(_debug_logger, "recv: {}", wi.n_items);
+            // auto ret = this->_socket.recv(
+            //     zmq::mutable_buffer(_circbuf->write_ptr(), wi.n_items * wi.item_size),
+            //     zmq::recv_flags::none);
+
+            // _circbuf->post_write(wi.n_items);
+            // notify_scheduler();
+            // auto recbuf = *ret;
+            // assert(recbuf.size == wi.n_items * wi.item_size);
+
+            // GR_LOG_DEBUG(_debug_logger, "nbytesrcv: {}", recbuf.size);
+            // std::cout << "    ---> msg received " << msg.size() << " bytes" <<
+            // std::endl;
+        }
+    });
+
+    t.detach();
+}
+
+} // namespace gr

--- a/runtime/lib/edge.cc
+++ b/runtime/lib/edge.cc
@@ -48,6 +48,7 @@ bool edge::has_custom_buffer()
 }
 
 buffer_factory_function edge::buffer_factory() { return _buffer_properties->factory(); }
+buffer_reader_factory_function edge::buffer_reader_factory() { return _buffer_properties->reader_factory(); }
 std::shared_ptr<buffer_properties> edge::buf_properties() { return _buffer_properties; }
 
 } // namespace gr

--- a/runtime/lib/meson.build
+++ b/runtime/lib/meson.build
@@ -3,7 +3,7 @@ incdir = [
 ]
 
 
-runtime_deps = [yaml_dep, spdlog_dep, threads_dep, fmt_dep, rt_dep, pmtf_dep, libdl_dep, pmtf_dep]
+runtime_deps = [yaml_dep, spdlog_dep, threads_dep, fmt_dep, rt_dep, pmtf_dep, libdl_dep, pmtf_dep, zmq_dep]
 
 libdir = get_option('libdir')
 prefix = get_option('prefix')
@@ -46,7 +46,8 @@ runtime_sources = [
   'buffer_cpu_vmcirc.cc',
   'buffer_cpu_vmcirc_sysv_shm.cc',
   # mmap requires librt - FIXME - handle this a conditional dependency
-  'buffer_cpu_vmcirc_mmap_shm_open.cc'
+  'buffer_cpu_vmcirc_mmap_shm_open.cc',
+  'buffer_net_zmq.cc'
 ]
 
 if USE_CUDA

--- a/schedulers/nbt/lib/scheduler_nbt.cc
+++ b/schedulers/nbt/lib/scheduler_nbt.cc
@@ -30,7 +30,7 @@ void scheduler_nbt::initialize(flat_graph_sptr fg, flowgraph_monitor_sptr fgmon)
 
 
     auto bufman = std::make_shared<buffer_manager>(s_fixed_buf_size);
-    bufman->initialize_buffers(fg, _default_buf_properties);
+    bufman->initialize_buffers(fg, _default_buf_properties, base());
 
 
     //  Partition the flowgraph according to how blocks are specified in groups

--- a/schedulers/nbt/test/meson.build
+++ b/schedulers/nbt/test/meson.build
@@ -71,6 +71,19 @@ if get_option('enable_testing')
         install : true)
     test('NBT Tags Tests', e)
 
+    srcs = ['qa_zmq_buffers.cc']
+    e = executable('qa_zmq_buffers', 
+        srcs, 
+        include_directories : incdir, 
+        link_language : 'cpp',
+        dependencies: [newsched_runtime_dep,
+                    newsched_blocklib_blocks_dep,
+                    newsched_blocklib_math_dep,
+                    newsched_scheduler_nbt_dep,
+                    gtest_dep], 
+        install : true)
+    test('NBT ZMQ Custom Buffers', e)
+
     test('Basic Python', py3, args : files('qa_basic.py'), env: TEST_ENV)
     test('Block Parameters', py3, args : files('qa_parameters.py'), env: TEST_ENV)
 

--- a/schedulers/nbt/test/qa_zmq_buffers.cc
+++ b/schedulers/nbt/test/qa_zmq_buffers.cc
@@ -1,0 +1,53 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <iostream>
+#include <thread>
+
+#include <gnuradio/blocks/copy.hh>
+#include <gnuradio/math/multiply_const.hh>
+#include <gnuradio/blocks/vector_sink.hh>
+#include <gnuradio/blocks/vector_source.hh>
+#include <gnuradio/blocks/head.hh>
+#include <gnuradio/flowgraph.hh>
+#include <gnuradio/schedulers/nbt/scheduler_nbt.hh>
+#include <gnuradio/buffer_cpu_vmcirc.hh>
+#include <gnuradio/buffer_net_zmq.hh>
+
+using namespace gr;
+
+TEST(SchedulerMTTest, ZMQBuffers)
+{
+    int nsamples = 100000;
+    std::vector<float> input_data(nsamples);
+    for (int i = 0; i < nsamples; i++) {
+        input_data[i] = i;
+    }
+    auto src = blocks::vector_source_f::make({input_data, true});
+    // auto copy1 = blocks::copy::make({sizeof(float)});
+    auto copy2 = blocks::copy::make({sizeof(float)});
+    auto hd = blocks::head::make({nsamples, sizeof(float)});
+    auto snk1 = blocks::vector_sink_f::make({});
+
+    flowgraph_sptr fg(new flowgraph());
+    // fg->connect(src, 0, copy1, 0);
+    fg->connect(src, 0, copy2, 0)
+        ->set_custom_buffer(buffer_net_zmq_properties::make("127.0.0.1", 1234));
+    fg->connect(copy2, 0, hd, 0);
+    fg->connect(hd, 0, snk1, 0);
+
+    fg->start();
+    fg->wait();
+
+    EXPECT_EQ(snk1->data().size(), input_data.size());
+    EXPECT_EQ(snk1->data(), input_data);
+
+    auto data = snk1->data();
+    for (int i=0; i<data.size(); i++)
+    {
+        if (input_data[i] != data[i])
+        {
+            std::cout << i << ": " << input_data[i] << " " << data[i] << std::endl;
+        }
+    }
+}


### PR DESCRIPTION
The goal of this is to make buffers that can span hosts on different machines.

Required a bit of reworking the buffer API

Signed-off-by: Josh Morman <jmorman@gnuradio.org>