### PR TITLE
Boost removal

### DIFF
--- a/blocklib/fft/lib/fftw_fft.cc
+++ b/blocklib/fft/lib/fftw_fft.cc
@@ -12,6 +12,10 @@
 // #include <gnuradio/sys_paths.h>
 #include <fftw3.h>
 #include <volk/volk.h>
+#include <fstream>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 #ifdef _WIN32 // http://www.fftw.org/install/windows.html#DLLwisdom
 static void my_fftw_write_char(char c, void* f) { fputc(c, (FILE*)f); }
@@ -39,13 +43,13 @@ static int my_fftw_read_char(void* f) { return fgetc((FILE*)f); }
 
 #include <gnuradio/prefs.hh>
 
-#include <boost/interprocess/sync/file_lock.hpp>
+// #include <boost/interprocess/sync/file_lock.hpp>
 namespace fs = std::filesystem;
 
 namespace gr {
 namespace fft {
 static std::mutex wisdom_thread_mutex;
-boost::interprocess::file_lock wisdom_lock;
+// boost::interprocess::file_lock wisdom_lock;
 static bool wisdom_lock_init_done = false; // Modify while holding 'wisdom_thread_mutex'
 
 gr_complex* malloc_complex(int size)
@@ -94,7 +98,7 @@ static void wisdom_lock_init()
                                  wisdom_lock_file);
     }
     close(fd);
-    wisdom_lock = boost::interprocess::file_lock(wisdom_lock_file.c_str());
+    // wisdom_lock = boost::interprocess::file_lock(wisdom_lock_file.c_str());
     wisdom_lock_init_done = true;
 }
 
@@ -102,13 +106,13 @@ static void lock_wisdom()
 {
     wisdom_thread_mutex.lock();
     wisdom_lock_init();
-    wisdom_lock.lock();
+    // wisdom_lock.lock();
 }
 
 static void unlock_wisdom()
 {
     // Assumes 'lock_wisdom' has already been called (i.e. this file_lock is valid)
-    wisdom_lock.unlock();
+    // wisdom_lock.unlock();
     wisdom_thread_mutex.unlock();
 }
 

--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,6 @@ IMPLEMENT_CPU = true
 
 SCRIPTS_DIR=join_paths(meson.project_source_root(),'utils','blockbuilder','scripts')
 
-boost_dep = dependency('boost', modules : ['system','thread'], version : '>=1.65')
 volk_dep = dependency('volk', version : '>=2.2')
 yaml_dep = dependency('yaml-cpp', version : '>=0.6')
 fmt_dep = dependency('fmt', method: 'cmake', modules: ['fmt::fmt'])

--- a/runtime/include/gnuradio/high_res_timer.hh
+++ b/runtime/include/gnuradio/high_res_timer.hh
@@ -11,7 +11,7 @@
 #pragma once
 
 #include <gnuradio/api.h>
-#include <boost/date_time/posix_time/posix_time.hpp>
+#include <chrono>
 
 ////////////////////////////////////////////////////////////////////////
 // Use architecture defines to determine the implementation
@@ -143,11 +143,14 @@ inline gr::high_res_timer_type gr::high_res_timer_tps(void)
 ////////////////////////////////////////////////////////////////////////
 inline gr::high_res_timer_type gr::high_res_timer_epoch(void)
 {
+    std::chrono::time_point currently = std::chrono::time_point_cast<std::chrono::nanoseconds>(
+        std::chrono::system_clock::now()
+    );
+    std::chrono::duration nanos_since_utc_epoch = currently.time_since_epoch();
+
     static const double hrt_ticks_per_utc_ticks =
-        gr::high_res_timer_tps() /
-        double(boost::posix_time::time_duration::ticks_per_second());
-    boost::posix_time::time_duration utc =
-        boost::posix_time::microsec_clock::universal_time() -
-        boost::posix_time::from_time_t(0);
-    return gr::high_res_timer_now() - utc.ticks() * hrt_ticks_per_utc_ticks;
+            gr::high_res_timer_tps() /
+            double(1000000000);
+
+    return gr::high_res_timer_now() - nanos_since_utc_epoch.count() * hrt_ticks_per_utc_ticks;
 }

--- a/runtime/lib/constants.cc.in
+++ b/runtime/lib/constants.cc.in
@@ -13,7 +13,10 @@
 #endif
 
 #include <gnuradio/constants.hh>
-#include <boost/dll/runtime_symbol_info.hpp>
+//#include <boost/dll/runtime_symbol_info.hpp>
+#include <dlfcn.h>
+#include <iostream>
+#include <memory>
 #include <cstdlib>
 #include <filesystem>
 
@@ -28,7 +31,13 @@ const std::string prefix()
         return prefix;
 
     path prefix_rel_lib = "@prefix_relative_to_lib@";
-    path gr_runtime_lib_path = boost::dll::this_line_location().string();
+    //path gr_runtime_lib_path = boost::dll::this_line_location().string();
+    Dl_info info;
+    // Some of the libc headers miss `const` in `dladdr(const void*, Dl_info*)`
+
+    auto ptr = std::addressof(::gr::prefix);
+    const int res = dladdr(const_cast<void*>(reinterpret_cast<void *>(ptr)), &info);
+    path gr_runtime_lib_path = info.dli_fname;
     // Canonize before decomposing path so result is reliable and without symlinks
     path canonical_lib_path = std::filesystem::canonical(gr_runtime_lib_path);
     path prefix_path = canonical_lib_path.parent_path() / prefix_rel_lib;

--- a/schedulers/nbt/bench/cuda/meson.build
+++ b/schedulers/nbt/bench/cuda/meson.build
@@ -9,5 +9,5 @@ executable('bm_nbt_cuda_copy',
                    cuda_dep,
                    newsched_blocklib_blocks_dep,
                    newsched_scheduler_nbt_dep,
-                   boost_po_dep], 
+                   CLI11_dep], 
     install : true)


### PR DESCRIPTION
There are some shortcuts in here and we lose some of the cross platform compatibility, but it is a good starting point to not have boost

For fftw, the wisdom lock is disabled.  This needs to be done some other way

Fixes #151