### PR TITLE
analog: Add top level enums and sig_source

### DIFF
--- a/blocklib/analog/enums.yml
+++ b/blocklib/analog/enums.yml
@@ -1,0 +1,18 @@
+waveform_type:
+  # type: uint32_t # Only specify if necessary
+  enumerators:  
+  - id: constant
+    value: 100 # unnecessary
+  - id: sin
+  - id: cos
+  - id: square
+  - id: triangle
+  - id: sawtooth
+
+noise_type:
+  enumerators:
+  - id: uniform
+    value: 200 # unnecessary
+  - id: gaussian
+  - id: laplacian
+  - id: impulse

--- a/blocklib/analog/sig_source/.gitignore
+++ b/blocklib/analog/sig_source/.gitignore
@@ -1,0 +1,1 @@
+meson.build

--- a/blocklib/analog/sig_source/sig_source.yml
+++ b/blocklib/analog/sig_source/sig_source.yml
@@ -1,0 +1,63 @@
+module: analog
+block: sig_source
+label: Signal Source
+blocktype: sync_block
+includes:
+  - gnuradio/analog/enums.h
+  
+typekeys: 
+  - id: T
+    type: class
+    options: 
+      - value: int8_t
+        suffix: b
+      - value: int16_t
+        suffix: s  
+      - value: int32_t 
+        suffix: i 
+      - value: float
+        suffix: f   
+      - value: gr_complex 
+        suffix: c 
+
+parameters:
+-   id: sampling_freq
+    label: Sampling Freq
+    dtype: double
+    settable: true
+-   id: waveform
+    label: Waveform
+    dtype: gr::analog::waveform_type
+    is_enum: true
+    settable: true
+-   id: frequency
+    label: Wave Freq
+    dtype: double
+    settable: true
+-   id: ampl
+    label: Amplitude
+    dtype: double
+    settable: true
+-   id: offset
+    label: Offset
+    dtype: T
+    settable: true
+    default: 0
+-   id: phase
+    label: Phase
+    dtype: double
+    settable: true
+    default: 0    
+
+# Example Ports
+ports:
+-   domain: stream
+    id: out
+    direction: output
+    type: typekeys/T
+
+implementations:
+-   id: cpu
+# -   id: cuda
+
+file_format: 1

--- a/blocklib/analog/sig_source/sig_source_cpu.cc
+++ b/blocklib/analog/sig_source/sig_source_cpu.cc
@@ -1,0 +1,215 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2022 Josh Morman
+ *
+ * This file is part of GNU Radio
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ */
+
+#include "sig_source_cpu.h"
+#include "sig_source_cpu_gen.h"
+
+#include <algorithm>
+#include <gnuradio/grmath.h>
+
+namespace gr {
+namespace analog {
+
+template <class T>
+sig_source_cpu<T>::sig_source_cpu(const typename sig_source<T>::block_args& args)
+    : INHERITED_CONSTRUCTORS(T)
+{
+    this->set_frequency(args.frequency);
+    this->set_phase(args.phase);
+}
+
+template <typename T>
+work_return_code_t sig_source_cpu<T>::work(std::vector<block_work_input_sptr>& work_input,
+                                         std::vector<block_work_output_sptr>& work_output)
+{
+    auto optr = work_output[0]->items<T>();
+    auto noutput_items = work_output[0]->n_items;
+
+    T t;
+    std::scoped_lock l(d_mutex);
+
+    auto offset = pmtf::get_as<T>(*this->param_offset);
+    auto ampl = pmtf::get_as<float>(*this->param_ampl);
+    auto waveform = static_cast<waveform_type>(pmtf::get_as<int>(*this->param_waveform));
+
+    switch (waveform) {
+    case waveform_type::constant:
+        t = (T)ampl + offset;
+        std::fill_n(optr, noutput_items, t);
+        break;
+
+    case waveform_type::sin:
+        d_nco.sin(optr, noutput_items, ampl);
+        if (offset == 0)
+            break;
+
+        for (int i = 0; i < noutput_items; i++) {
+            optr[i] += offset;
+        }
+        break;
+    case waveform_type::cos:
+        d_nco.cos(optr, noutput_items, ampl);
+        if (offset == 0)
+            break;
+
+        for (int i = 0; i < noutput_items; i++) {
+            optr[i] += offset;
+        }
+        break;
+
+        /* The square wave is high from -PI to 0. */
+    case waveform_type::square:
+        t = (T)ampl + offset;
+        for (int i = 0; i < noutput_items; i++) {
+            if (d_nco.get_phase() < 0)
+                optr[i] = t;
+            else
+                optr[i] = offset;
+            d_nco.step();
+        }
+        break;
+
+        /* The triangle wave rises from -PI to 0 and falls from 0 to PI. */
+    case waveform_type::triangle:
+        for (int i = 0; i < noutput_items; i++) {
+            double t = ampl * d_nco.get_phase() / GR_M_PI;
+            if (d_nco.get_phase() < 0)
+                optr[i] = static_cast<T>(t + ampl + offset);
+            else
+                optr[i] = static_cast<T>(-1 * t + ampl + offset);
+            d_nco.step();
+        }
+        break;
+
+        /* The saw tooth wave rises from -PI to PI. */
+    case waveform_type::sawtooth:
+        for (int i = 0; i < noutput_items; i++) {
+            t = static_cast<T>(ampl * d_nco.get_phase() / (2 * GR_M_PI) + ampl / 2 +
+                               offset);
+            optr[i] = t;
+            d_nco.step();
+        }
+        break;
+    default:
+        throw std::runtime_error("analog::sig_source: invalid waveform");
+    }
+
+    this->produce_each(noutput_items, work_output);
+    return work_return_code_t::WORK_OK;
+}
+
+template <>
+work_return_code_t sig_source_cpu<gr_complex>::work(std::vector<block_work_input_sptr>& work_input,
+                                         std::vector<block_work_output_sptr>& work_output)
+{
+    auto optr = work_output[0]->items<gr_complex>();
+    auto noutput_items = work_output[0]->n_items;
+
+    gr_complex t;
+    std::scoped_lock l(d_mutex);
+
+    auto offset = pmtf::get_as<gr_complex>(*this->param_offset);
+    auto ampl = pmtf::get_as<float>(*this->param_ampl);
+    auto waveform = static_cast<waveform_type>(pmtf::get_as<int>(*this->param_waveform));
+
+    switch (waveform) {
+    case waveform_type::constant:
+        t = (gr_complex)ampl + offset;
+        std::fill_n(optr, noutput_items, t);
+        break;
+
+    case waveform_type::sin:
+    case waveform_type::cos:
+        d_nco.sincos(optr, noutput_items, ampl);
+        if (offset == gr_complex(0, 0))
+            break;
+
+        for (int i = 0; i < noutput_items; i++) {
+            optr[i] += offset;
+        }
+        break;
+
+        /* Implements a real square wave high from -PI to 0.
+         * The imaginary square wave leads by 90 deg.
+         */
+    case waveform_type::square:
+        for (int i = 0; i < noutput_items; i++) {
+            if (d_nco.get_phase() < -1 * GR_M_PI / 2)
+                optr[i] = gr_complex(ampl, 0) + offset;
+            else if (d_nco.get_phase() < 0)
+                optr[i] = gr_complex(ampl, ampl) + offset;
+            else if (d_nco.get_phase() < GR_M_PI / 2)
+                optr[i] = gr_complex(0, ampl) + offset;
+            else
+                optr[i] = offset;
+            d_nco.step();
+        }
+        break;
+
+        /* Implements a real triangle wave rising from -PI to 0 and
+         * falling from 0 to PI. The imaginary triangle wave leads by
+         * 90 deg.
+         */
+    case waveform_type::triangle:
+        for (int i = 0; i < noutput_items; i++) {
+            if (d_nco.get_phase() < -1 * GR_M_PI / 2) {
+                optr[i] =
+                    gr_complex(ampl * d_nco.get_phase() / GR_M_PI + ampl,
+                               -1 * ampl * d_nco.get_phase() / GR_M_PI - ampl / 2) +
+                    offset;
+            } else if (d_nco.get_phase() < 0) {
+                optr[i] = gr_complex(ampl * d_nco.get_phase() / GR_M_PI + ampl,
+                                     ampl * d_nco.get_phase() / GR_M_PI + ampl / 2) +
+                          offset;
+            } else if (d_nco.get_phase() < GR_M_PI / 2) {
+                optr[i] = gr_complex(-1 * ampl * d_nco.get_phase() / GR_M_PI + ampl,
+                                     ampl * d_nco.get_phase() / GR_M_PI + ampl / 2) +
+                          offset;
+            } else {
+                optr[i] = gr_complex(-1 * ampl * d_nco.get_phase() / GR_M_PI + ampl,
+                                     -1 * ampl * d_nco.get_phase() / GR_M_PI +
+                                         3 * ampl / 2) +
+                          offset;
+            }
+            d_nco.step();
+        }
+        break;
+
+        /* Implements a real saw tooth wave rising from -PI to PI.
+         * The imaginary saw tooth wave leads by 90 deg.
+         */
+    case waveform_type::sawtooth:
+        for (int i = 0; i < noutput_items; i++) {
+            if (d_nco.get_phase() < -1 * GR_M_PI / 2) {
+                optr[i] =
+                    gr_complex(ampl * d_nco.get_phase() / (2 * GR_M_PI) + ampl / 2,
+                               ampl * d_nco.get_phase() / (2 * GR_M_PI) +
+                                   5 * ampl / 4) +
+                    offset;
+            } else {
+                optr[i] =
+                    gr_complex(ampl * d_nco.get_phase() / (2 * GR_M_PI) + ampl / 2,
+                               ampl * d_nco.get_phase() / (2 * GR_M_PI) + ampl / 4) +
+                    offset;
+            }
+            d_nco.step();
+        }
+        break;
+    default:
+        throw std::runtime_error("analog::sig_source: invalid waveform");
+    }
+
+    this->produce_each(noutput_items, work_output);
+    return work_return_code_t::WORK_OK;
+}
+
+} /* namespace analog */
+} /* namespace gr */
+

--- a/blocklib/analog/sig_source/sig_source_cpu.h
+++ b/blocklib/analog/sig_source/sig_source_cpu.h
@@ -1,0 +1,61 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2022 Josh Morman
+ *
+ * This file is part of GNU Radio
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ */
+
+#pragma once
+
+#include <gnuradio/analog/sig_source.h>
+#include <gnuradio/fxpt_nco.h>
+#include <mutex>
+#include <gnuradio/grmath.h>
+
+namespace gr {
+namespace analog {
+
+template <class T>
+class sig_source_cpu : public sig_source<T>
+{
+public:
+    sig_source_cpu(const typename sig_source<T>::block_args& args);
+    
+    virtual work_return_code_t work(std::vector<block_work_input_sptr>& work_input,
+                                    std::vector<block_work_output_sptr>& work_output) override;
+
+
+    void on_parameter_change(param_action_sptr action) override
+    {
+        // This will set the underlying PMT
+        block::on_parameter_change(action);
+
+        // Do more updating for certain parameters
+        if (action->id() == sig_source<T>::id_phase)
+        {
+            auto phase =  pmtf::get_as<double>(*this->param_phase);
+            d_nco.set_phase(phase);
+        }
+        else if (action->id() == sig_source<T>::id_frequency)
+        {
+            auto freq =  pmtf::get_as<double>(*this->param_frequency);
+            auto samp_freq = pmtf::get_as<double>(*this->param_sampling_freq);
+            d_nco.set_freq(2 * GR_M_PI * freq / samp_freq);
+        }
+    }
+
+
+private:
+    // Declare private variables here
+    gr::fxpt_nco d_nco;
+
+    // sig_source has some non thread safe accessors (for now)
+    std::mutex d_mutex;
+};
+
+
+} // namespace analog
+} // namespace gr

--- a/blocklib/analog/test/meson.build
+++ b/blocklib/analog/test/meson.build
@@ -3,6 +3,7 @@
 ###################################################
 
 if get_option('enable_testing')
+    test('qa_sig_source', find_program('qa_sig_source.py'), env: TEST_ENV)
     # test('qa_agc', find_program('qa_agc.py'), env: TEST_ENV)
     # if (cuda_available and get_option('enable_cuda'))
     # test('qa_cufft', find_program('qa_cufft.py'), env: TEST_ENV)

--- a/blocklib/analog/test/qa_sig_source.py
+++ b/blocklib/analog/test/qa_sig_source.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright 2004, 2007, 2010, 2012, 2013, 2020 Free Software Foundation, Inc.
 #

--- a/blocklib/analog/test/qa_sig_source.py
+++ b/blocklib/analog/test/qa_sig_source.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python
+#
+# Copyright 2004, 2007, 2010, 2012, 2013, 2020 Free Software Foundation, Inc.
+#
+# This file is part of GNU Radio
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+#
+
+
+import math
+# import pmt
+from gnuradio import gr, gr_unittest, analog, blocks
+
+
+class test_sig_source(gr_unittest.TestCase):
+    def setUp(self):
+        self.tb = gr.top_block()
+
+    def tearDown(self):
+        self.tb = None
+
+    def test_const_f(self):
+        tb = self.tb
+        expected_result = [1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5, 1.5]
+        src1 = analog.sig_source_f(1e6, analog.waveform_type.constant, 0, 1.5)
+        op = blocks.head(10)
+        dst1 = blocks.vector_sink_f()
+        tb.connect(src1, op)
+        tb.connect(op, dst1)
+        tb.run()
+        dst_data = dst1.data()
+        self.assertEqual(expected_result, dst_data)
+
+    def test_const_i(self):
+        tb = self.tb
+        expected_result = [1, 1, 1, 1]
+        src1 = analog.sig_source_i(1e6, analog.waveform_type.constant, 0, 1)
+        op = blocks.head(4)
+        dst1 = blocks.vector_sink_i()
+        tb.connect(src1, op)
+        tb.connect(op, dst1)
+        tb.run()
+        dst_data = dst1.data()
+        self.assertEqual(expected_result, dst_data)
+
+    def test_const_b(self):
+        tb = self.tb
+        expected_result = [1, 1, 1, 1]
+        src1 = analog.sig_source_b(1e6, analog.waveform_type.constant, 0, 1)
+        op = blocks.head(4)
+        dst1 = blocks.vector_sink_b()
+        tb.connect(src1, op)
+        tb.connect(op, dst1)
+        tb.run()
+        dst_data = dst1.data()
+        self.assertEqual(expected_result, dst_data)
+
+    def test_sine_f(self):
+        tb = self.tb
+        sqrt2 = math.sqrt(2) / 2
+        expected_result = [0, sqrt2, 1, sqrt2, 0, -sqrt2, -1, -sqrt2, 0]
+        src1 = analog.sig_source_f(8, analog.waveform_type.sin, 1.0, 1.0)
+        op = blocks.head(9)
+        dst1 = blocks.vector_sink_f()
+        tb.connect(src1, op)
+        tb.connect(op, dst1)
+        tb.run()
+        dst_data = dst1.data()
+        self.assertFloatTuplesAlmostEqual(expected_result, dst_data, 5)
+
+    def test_sine_b(self):
+        tb = self.tb
+        sqrt2 = math.sqrt(2) / 2
+        temp_result = [0, sqrt2, 1, sqrt2, 0, -sqrt2, -1, -sqrt2, 0]
+        amp = 8
+        expected_result = tuple([int(z * amp) for z in temp_result])
+        src1 = analog.sig_source_b(8, analog.waveform_type.sin, 1.0, amp)
+        op = blocks.head(9)
+        dst1 = blocks.vector_sink_b()
+        tb.connect(src1, op)
+        tb.connect(op, dst1)
+        tb.run()
+        dst_data = dst1.data()
+        # Let the python know we are dealing with signed int behind scenes
+        dst_data_signed = [b if b < 127 else (256 - b) * -1 for b in dst_data]
+        self.assertFloatTuplesAlmostEqual(expected_result, dst_data_signed)
+
+    def test_cosine_f(self):
+        tb = self.tb
+        sqrt2 = math.sqrt(2) / 2
+        expected_result = [1, sqrt2, 0, -sqrt2, -1, -sqrt2, 0, sqrt2, 1]
+        src1 = analog.sig_source_f(8, analog.waveform_type.cos, 1.0, 1.0)
+        op = blocks.head(9)
+        dst1 = blocks.vector_sink_f()
+        tb.connect(src1, op)
+        tb.connect(op, dst1)
+        tb.run()
+        dst_data = dst1.data()
+        self.assertFloatTuplesAlmostEqual(expected_result, dst_data, 5)
+
+    def test_cosine_c(self):
+        tb = self.tb
+        sqrt2 = math.sqrt(2) / 2
+        sqrt2j = 1j * math.sqrt(2) / 2
+        expected_result = [
+            1, sqrt2 + sqrt2j, 1j, -sqrt2 + sqrt2j, -1, -sqrt2 - sqrt2j, -1j,
+            sqrt2 - sqrt2j, 1
+        ]
+        src1 = analog.sig_source_c(8, analog.waveform_type.cos, 1.0, 1.0)
+        op = blocks.head(9)
+        dst1 = blocks.vector_sink_c()
+        tb.connect(src1, op)
+        tb.connect(op, dst1)
+        tb.run()
+        dst_data = dst1.data()
+        self.assertFloatTuplesAlmostEqual(expected_result, dst_data, 5)
+
+    def test_sqr_c(self):
+        tb = self.tb  # arg6 is a bit before -PI/2
+        expected_result = [1j, 1j, 0, 0, 1, 1, 1 + 0j, 1 + 1j, 1j]
+        src1 = analog.sig_source_c(8, analog.waveform_type.square, 1.0, 1.0)
+        op = blocks.head(9)
+        dst1 = blocks.vector_sink_c()
+        tb.connect(src1, op)
+        tb.connect(op, dst1)
+        tb.run()
+        dst_data = dst1.data()
+        self.assertEqual(expected_result, dst_data)
+
+    def test_tri_c(self):
+        tb = self.tb
+        expected_result = [
+            1 + .5j, .75 + .75j, .5 + 1j, .25 + .75j, 0 + .5j, .25 + .25j,
+            .5 + 0j, .75 + .25j, 1 + .5j
+        ]
+        src1 = analog.sig_source_c(8, analog.waveform_type.triangle, 1.0, 1.0)
+        op = blocks.head(9)
+        dst1 = blocks.vector_sink_c()
+        tb.connect(src1, op)
+        tb.connect(op, dst1)
+        tb.run()
+        dst_data = dst1.data()
+        self.assertComplexTuplesAlmostEqual(expected_result, dst_data, 5)
+
+    def test_saw_c(self):
+        tb = self.tb
+        expected_result = [
+            .5 + .25j, .625 + .375j, .75 + .5j, .875 + .625j, 0 + .75j,
+            .125 + .875j, .25 + 1j, .375 + .125j, .5 + .25j
+        ]
+        src1 = analog.sig_source_c(8, analog.waveform_type.sawtooth, 1.0, 1.0)
+        op = blocks.head(9)
+        dst1 = blocks.vector_sink_c()
+        tb.connect(src1, op)
+        tb.connect(op, dst1)
+        tb.run()
+        dst_data = dst1.data()
+        self.assertComplexTuplesAlmostEqual(expected_result, dst_data, 5)
+
+    def test_sqr_f(self):
+        tb = self.tb
+        expected_result = [0, 0, 0, 0, 1, 1, 1, 1, 0]
+        src1 = analog.sig_source_f(8, analog.waveform_type.square, 1.0, 1.0)
+        op = blocks.head(9)
+        dst1 = blocks.vector_sink_f()
+        tb.connect(src1, op)
+        tb.connect(op, dst1)
+        tb.run()
+        dst_data = dst1.data()
+        self.assertEqual(expected_result, dst_data)
+
+    def test_tri_f(self):
+        tb = self.tb
+        expected_result = [1, .75, .5, .25, 0, .25, .5, .75, 1]
+        src1 = analog.sig_source_f(8, analog.waveform_type.triangle, 1.0, 1.0)
+        op = blocks.head(9)
+        dst1 = blocks.vector_sink_f()
+        tb.connect(src1, op)
+        tb.connect(op, dst1)
+        tb.run()
+        dst_data = dst1.data()
+        self.assertFloatTuplesAlmostEqual(expected_result, dst_data, 5)
+
+    def test_saw_f(self):
+        tb = self.tb
+        expected_result = [.5, .625, .75, .875, 0, .125, .25, .375, .5]
+        src1 = analog.sig_source_f(8, analog.waveform_type.sawtooth, 1.0, 1.0)
+        op = blocks.head(9)
+        dst1 = blocks.vector_sink_f()
+        tb.connect(src1, op)
+        tb.connect(op, dst1)
+        tb.run()
+        dst_data = dst1.data()
+        self.assertFloatTuplesAlmostEqual(expected_result, dst_data, 5)
+
+    # def test_cmd_msg(self):
+    #     src = analog.sig_source_c(8, analog.GR_SIN_WAVE, 1.0, 1.0)
+    #     op = blocks.head(gr.sizeof_gr_complex, 9)
+    #     snk = blocks.vector_sink_c()
+    #     self.tb.connect(src, op, snk)
+    #     self.assertAlmostEqual(src.frequency(), 1.0)
+
+    #     frequency = 3.0
+    #     amplitude = 10
+    #     offset = -1.0
+
+    #     src._post(
+    #         pmt.to_pmt('cmd'),
+    #         pmt.to_pmt({
+    #             "freq": frequency,
+    #             "ampl": amplitude,
+    #             "offset": offset
+    #         }))
+    #     self.tb.run()
+
+    #     self.assertAlmostEqual(src.frequency(), frequency)
+    #     self.assertAlmostEqual(src.amplitude(), amplitude)
+    #     self.assertAlmostEqual(src.offset(), offset)
+
+
+if __name__ == '__main__':
+    gr_unittest.run(test_sig_source)

--- a/blocklib/blocks/msg_forward/msg_forward.yml
+++ b/blocklib/blocks/msg_forward/msg_forward.yml
@@ -3,7 +3,7 @@ block: msg_forward
 label: Message Forward
 blocktype: sync_block
 includes: 
-  - value: pmtf/wrap.hpp
+  - pmtf/wrap.hpp
 
 parameters:
 -   id: max_messages

--- a/blocklib/qtgui/freq_sink/freq_sink.yml
+++ b/blocklib/qtgui/freq_sink/freq_sink.yml
@@ -78,23 +78,23 @@ ports:
     type: typekeys/T
 
 includes: 
-  - value: gnuradio/fft/fftw_fft.h
-  - value: gnuradio/fft/window.h
-  - value: gnuradio/qtgui/utils.h
-  - value: gnuradio/qtgui/trigger_mode.h
-  - value: qapplication.h
-  - value: qwt_legend.h
-  - value: qwt_painter.h
-  - value: qwt_plot.h
-  - value: qwt_plot_canvas.h
-  - value: qwt_plot_curve.h
-  - value: qwt_plot_magnifier.h
-  - value: qwt_plot_marker.h
-  - value: qwt_plot_panner.h
-  - value: qwt_plot_zoomer.h
-  - value: qwt_scale_engine.h
-  - value: qwt_scale_widget.h
-  - value: qwt_symbol.h
+  - gnuradio/fft/fftw_fft.h
+  - gnuradio/fft/window.h
+  - gnuradio/qtgui/utils.h
+  - gnuradio/qtgui/trigger_mode.h
+  - qapplication.h
+  - qwt_legend.h
+  - qwt_painter.h
+  - qwt_plot.h
+  - qwt_plot_canvas.h
+  - qwt_plot_curve.h
+  - qwt_plot_magnifier.h
+  - qwt_plot_marker.h
+  - qwt_plot_panner.h
+  - qwt_plot_zoomer.h
+  - qwt_scale_engine.h
+  - qwt_scale_widget.h
+  - qwt_symbol.h
 
 callbacks:
     # virtual void exec_() = 0;

--- a/blocklib/qtgui/time_sink/time_sink.yml
+++ b/blocklib/qtgui/time_sink/time_sink.yml
@@ -59,19 +59,19 @@ parameters:
     serializable: false
 # Includes go in the blockname.h
 includes: 
-  - value: qapplication.h
-  - value: qwt_legend.h
-  - value: qwt_painter.h
-  - value: qwt_plot.h
-  - value: qwt_plot_canvas.h
-  - value: qwt_plot_curve.h
-  - value: qwt_plot_magnifier.h
-  - value: qwt_plot_marker.h
-  - value: qwt_plot_panner.h
-  - value: qwt_plot_zoomer.h
-  - value: qwt_scale_engine.h
-  - value: qwt_scale_widget.h
-  - value: qwt_symbol.h
+  - qapplication.h
+  - qwt_legend.h
+  - qwt_painter.h
+  - qwt_plot.h
+  - qwt_plot_canvas.h
+  - qwt_plot_curve.h
+  - qwt_plot_magnifier.h
+  - qwt_plot_marker.h
+  - qwt_plot_panner.h
+  - qwt_plot_zoomer.h
+  - qwt_scale_engine.h
+  - qwt_scale_widget.h
+  - qwt_symbol.h
 
 ports:
 -   domain: stream

--- a/blocklib/soapy/source/source.yml
+++ b/blocklib/soapy/source/source.yml
@@ -163,7 +163,7 @@ typekeys:
     #     suffix: ff 
 
 includes:
-  - value: gnuradio/soapy/block.h
+  - gnuradio/soapy/block.h
 
 parameters:
 -   id: device

--- a/blocklib/zeromq/push_sink/push_sink.yml
+++ b/blocklib/zeromq/push_sink/push_sink.yml
@@ -4,7 +4,7 @@ label: PUSH Sink
 blocktype: sync_block
 # inherits: gr::zeromq::base
 # includes: 
-#   - value: gnuradio/zeromq/base.h
+#   - gnuradio/zeromq/base.h
 
 parameters:
     - id: itemsize

--- a/gr/include/gnuradio/fxpt.h
+++ b/gr/include/gnuradio/fxpt.h
@@ -1,0 +1,91 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2004,2013 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ */
+
+#ifndef INCLUDED_GR_FXPT_H
+#define INCLUDED_GR_FXPT_H
+
+#include <gnuradio/api.h>
+#include <gnuradio/types.h>
+#include <cstdint>
+
+namespace gr {
+
+/*!
+ * \brief fixed point sine and cosine and friends.
+ * \ingroup misc
+ *
+ *   fixed pt	radians
+ *  ---------	--------
+ *   -2**31       -pi
+ *        0         0
+ *  2**31-1        pi - epsilon
+ */
+class GR_RUNTIME_API fxpt
+{
+    static constexpr int WORDBITS = 32;
+    static constexpr int NBITS = 10;
+    static constexpr uint32_t ACCUM_MASK = ((1 << (WORDBITS - NBITS)) - 1);
+    static const float s_sine_table[1 << NBITS][2];
+    static const float PI;
+    static const float TAU;
+    static const float TWO_TO_THE_31;
+
+public:
+    static int32_t float_to_fixed(float x)
+    {
+        // Fold x into -PI to PI.
+        int d = (int)std::floor(x / TAU + 0.5);
+        x -= d * TAU;
+        // And convert to an integer.
+        return (int32_t)((float)x * TWO_TO_THE_31 / PI);
+    }
+
+    static float fixed_to_float(int32_t x) { return x * (PI / TWO_TO_THE_31); }
+
+    /*!
+     * \brief Given a fixed point angle x, return float sine (x)
+     */
+    static float sin(int32_t x)
+    {
+        uint32_t ux = x;
+        int index = ux >> (WORDBITS - NBITS);
+        return s_sine_table[index][0] * (ux & ACCUM_MASK) + s_sine_table[index][1];
+    }
+
+    /*
+     * \brief Given a fixed point angle x, return float cosine (x)
+     */
+    static float cos(int32_t x)
+    {
+        uint32_t ux = x + 0x40000000;
+        int index = ux >> (WORDBITS - NBITS);
+        return s_sine_table[index][0] * (ux & ACCUM_MASK) + s_sine_table[index][1];
+    }
+
+    /*
+     * \brief Given a fixedpoint angle x, return float cos(x) and sin (x)
+     */
+    static void sincos(int32_t x, float* s, float* c)
+    {
+        uint32_t ux = x;
+        int sin_index = ux >> (WORDBITS - NBITS);
+        *s = s_sine_table[sin_index][0] * (ux & ACCUM_MASK) + s_sine_table[sin_index][1];
+
+        ux = x + 0x40000000;
+        int cos_index = ux >> (WORDBITS - NBITS);
+        *c = s_sine_table[cos_index][0] * (ux & ACCUM_MASK) + s_sine_table[cos_index][1];
+
+        return;
+    }
+};
+
+} /* namespace gr */
+
+#endif /* INCLUDED_GR_FXPT_H */

--- a/gr/include/gnuradio/fxpt_nco.h
+++ b/gr/include/gnuradio/fxpt_nco.h
@@ -1,0 +1,161 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2002,2004,2013 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ */
+
+#ifndef INCLUDED_GR_FXPT_NCO_H
+#define INCLUDED_GR_FXPT_NCO_H
+
+#include <gnuradio/api.h>
+#include <gnuradio/fxpt.h>
+#include <gnuradio/types.h>
+#include <cstdint>
+
+namespace gr {
+
+/*!
+ * \brief Numerically Controlled Oscillator (NCO)
+ * \ingroup misc
+ */
+class /*GR_RUNTIME_API*/ fxpt_nco
+{
+    uint32_t d_phase;
+    int32_t d_phase_inc;
+
+public:
+    fxpt_nco() : d_phase(0), d_phase_inc(0) {}
+
+    ~fxpt_nco() {}
+
+    // radians
+    void set_phase(float angle) { d_phase = gr::fxpt::float_to_fixed(angle); }
+
+    void adjust_phase(float delta_phase)
+    {
+        d_phase += gr::fxpt::float_to_fixed(delta_phase);
+    }
+
+    // angle_rate is in radians / step
+    void set_freq(float angle_rate)
+    {
+        d_phase_inc = gr::fxpt::float_to_fixed(angle_rate);
+    }
+
+    // angle_rate is a delta in radians / step
+    void adjust_freq(float delta_angle_rate)
+    {
+        d_phase_inc += gr::fxpt::float_to_fixed(delta_angle_rate);
+    }
+
+    // increment current phase angle
+
+    void step() { d_phase += d_phase_inc; }
+
+    void step(int n) { d_phase += d_phase_inc * n; }
+
+    // units are radians / step
+    float get_phase() const { return gr::fxpt::fixed_to_float(d_phase); }
+    float get_freq() const { return gr::fxpt::fixed_to_float(d_phase_inc); }
+
+    // compute sin and cos for current phase angle
+    void sincos(float* sinx, float* cosx) const
+    {
+        *sinx = gr::fxpt::sin(d_phase);
+        *cosx = gr::fxpt::cos(d_phase);
+    }
+
+    // compute cos and sin for a block of phase angles
+    void sincos(gr_complex* output, int noutput_items, double ampl = 1.0)
+    {
+        for (int i = 0; i < noutput_items; i++) {
+            output[i] =
+                gr_complex(gr::fxpt::cos(d_phase) * ampl, gr::fxpt::sin(d_phase) * ampl);
+            step();
+        }
+    }
+
+    // compute sin for a block of phase angles
+    void sin(float* output, int noutput_items, double ampl = 1.0)
+    {
+        for (int i = 0; i < noutput_items; i++) {
+            output[i] = (float)(gr::fxpt::sin(d_phase) * ampl);
+            step();
+        }
+    }
+
+    // compute cos for a block of phase angles
+    void cos(float* output, int noutput_items, double ampl = 1.0)
+    {
+        for (int i = 0; i < noutput_items; i++) {
+            output[i] = (float)(gr::fxpt::cos(d_phase) * ampl);
+            step();
+        }
+    }
+
+    // compute sin for a block of phase angles
+    void sin(std::int8_t* output, int noutput_items, double ampl = 1.0)
+    {
+        for (int i = 0; i < noutput_items; i++) {
+            output[i] = (std::int8_t)(gr::fxpt::sin(d_phase) * ampl);
+            step();
+        }
+    }
+
+    // compute cos for a block of phase angles
+    void cos(std::int8_t* output, int noutput_items, double ampl = 1.0)
+    {
+        for (int i = 0; i < noutput_items; i++) {
+            output[i] = (std::int8_t)(gr::fxpt::cos(d_phase) * ampl);
+            step();
+        }
+    }
+
+    // compute sin for a block of phase angles
+    void sin(short* output, int noutput_items, double ampl = 1.0)
+    {
+        for (int i = 0; i < noutput_items; i++) {
+            output[i] = (short)(gr::fxpt::sin(d_phase) * ampl);
+            step();
+        }
+    }
+
+    // compute cos for a block of phase angles
+    void cos(short* output, int noutput_items, double ampl = 1.0)
+    {
+        for (int i = 0; i < noutput_items; i++) {
+            output[i] = (short)(gr::fxpt::cos(d_phase) * ampl);
+            step();
+        }
+    }
+
+    // compute sin for a block of phase angles
+    void sin(int* output, int noutput_items, double ampl = 1.0)
+    {
+        for (int i = 0; i < noutput_items; i++) {
+            output[i] = (int)(gr::fxpt::sin(d_phase) * ampl);
+            step();
+        }
+    }
+
+    // compute cos for a block of phase angles
+    void cos(int* output, int noutput_items, double ampl = 1.0)
+    {
+        for (int i = 0; i < noutput_items; i++) {
+            output[i] = (int)(gr::fxpt::cos(d_phase) * ampl);
+            step();
+        }
+    }
+
+    // compute cos or sin for current phase angle
+    float cos() const { return gr::fxpt::cos(d_phase); }
+    float sin() const { return gr::fxpt::sin(d_phase); }
+};
+
+} /* namespace gr */
+
+#endif /* INCLUDED_GR_FXPT_NCO_H */

--- a/gr/include/gnuradio/sincos.h
+++ b/gr/include/gnuradio/sincos.h
@@ -1,0 +1,59 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2002,2004 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ */
+
+#ifndef INCLUDED_GR_SINCOS_H
+#define INCLUDED_GR_SINCOS_H
+
+#include <gnuradio/api.h>
+#include <cmath>
+
+namespace gr {
+
+#if defined(HAVE_SINCOS)
+
+inline void sincos(double x, double* sinx, double* cosx) { ::sincos(x, sinx, cosx); }
+
+#else
+
+inline void sincos(double x, double* sinx, double* cosx)
+{
+    *sinx = ::sin(x);
+    *cosx = ::cos(x);
+}
+
+#endif
+
+// ----------------------------------------------------------------
+
+#if defined(HAVE_SINCOSF)
+
+inline void sincosf(float x, float* sinx, float* cosx) { ::sincosf(x, sinx, cosx); }
+
+#elif defined(HAVE_SINF) && defined(HAVE_COSF)
+
+inline void sincosf(float x, float* sinx, float* cosx)
+{
+    *sinx = ::sinf(x);
+    *cosx = ::cosf(x);
+}
+
+#else
+
+inline void sincosf(float x, float* sinx, float* cosx)
+{
+    *sinx = ::sin(x);
+    *cosx = ::cos(x);
+}
+
+#endif
+
+} // namespace gr
+
+#endif /* INCLUDED_GR_SINCOS_H */

--- a/gr/lib/buffer_management.cc
+++ b/gr/lib/buffer_management.cc
@@ -29,7 +29,7 @@ void buffer_manager::initialize_buffers(flat_graph_sptr fg,
                     }
                     e->src().port()->set_buffer(buf);
 
-                    d_logger->info(
+                    d_debug_logger->debug(
                                 "Edge: {}, Buf: {}, {} bytes, {} items of size {}",
                                 e->identifier(),
                                 buf->type(),
@@ -40,7 +40,7 @@ void buffer_manager::initialize_buffers(flat_graph_sptr fg,
             }
             else {
                 auto buf = e->src().port()->buffer();
-                d_logger->info(
+                d_debug_logger->debug(
                             "Edge: {}, Buf(copy): {}, {} bytes, {} items of size {}",
                             e->identifier(),
                             buf->type(),
@@ -70,7 +70,7 @@ void buffer_manager::initialize_buffers(flat_graph_sptr fg,
 
                 if (ed[0]->buf_properties() &&
                     ed[0]->buf_properties()->reader_factory()) {
-                    d_logger->info(
+                    d_debug_logger->debug(
                                 "Creating Buffer Reader for Edge: {}, Independently",
                                 ed[0]->identifier());
                     p->set_buffer_reader(ed[0]->buf_properties()->reader_factory()(
@@ -79,7 +79,7 @@ void buffer_manager::initialize_buffers(flat_graph_sptr fg,
                 }
                 else {
                     
-                        d_logger->info(
+                        d_debug_logger->debug(
                         "Adding Buffer Reader for Edge: {}, to buffer on Block {}",
                         ed[0]->identifier(),
                         ed[0]->src().identifier());

--- a/gr/lib/flowgraph.cc
+++ b/gr/lib/flowgraph.cc
@@ -142,7 +142,8 @@ void flowgraph::wait()
 void flowgraph::run()
 {
     if (!d_runtime_sptr) {
-        throw new std::runtime_error("run: No runtime has been created");
+        d_runtime_sptr = gr::runtime::make();
+        d_runtime_sptr->initialize(base());
     }
     d_runtime_sptr->run();
 }

--- a/gr/lib/math/fxpt.cc
+++ b/gr/lib/math/fxpt.cc
@@ -1,0 +1,27 @@
+/* -*- c++ -*- */
+/*
+ * Copyright 2004,2013 Free Software Foundation, Inc.
+ *
+ * This file is part of GNU Radio
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <gnuradio/fxpt.h>
+
+namespace gr {
+
+const float fxpt::s_sine_table[1 << NBITS][2] = {
+#include "sine_table.h"
+};
+
+const float fxpt::PI = 3.14159265358979323846;
+const float fxpt::TAU = 2.0 * 3.14159265358979323846;
+const float fxpt::TWO_TO_THE_31 = 2147483648.0;
+
+} /* namespace gr */

--- a/gr/lib/math/gen_sine_table.py
+++ b/gr/lib/math/gen_sine_table.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+#
+# Copyright 2004 Free Software Foundation, Inc.
+#
+# This file is part of GNU Radio
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+#
+
+import math
+import sys
+import argparse
+import shutil
+import os
+
+def parse_args():
+    """Parses commandline args."""
+    desc='Generate the Sin/Cos lookup tables'
+    parser = argparse.ArgumentParser(description=desc)
+    
+    parser.add_argument("--output", default="/tmp/sin_table.h")
+    parser.add_argument("--output_copy", default=None)
+    return parser.parse_args()
+
+def gen_approx_table(f, nentries, min_x, max_x):
+    """return a list of nentries containing tuples of the form:
+    (m, c).  min_x and max_x specify the domain
+    of the table.
+    """
+    r = []
+    incx = float(max_x - min_x) / nentries
+    for i in range(nentries):
+        a = (i * incx) + min_x
+        b = ((i + 1) * incx) + min_x
+        m = (f(b) - f(a)) / (b - a)
+        c = f(a)
+        r.append((m, c))
+    return r
+
+
+def scaled_sine(x):
+    return math.sin(x * math.pi / 2**31)
+
+
+def gen_sine_table(args):
+    nbits = 10
+    nentries = 2**nbits
+
+    # min_x = -2**31
+    # max_x =  2**31-1
+    min_x = 0
+    max_x = 2**32 - 1
+    t = gen_approx_table(scaled_sine, nentries, min_x, max_x)
+
+    with open(args.output,'w') as f:
+        for e in t:
+            f.write('  { %22.15e, %22.15e },\n' % (e[0], e[1]))
+
+    if args.output_copy:
+        if not os.path.exists(os.path.dirname(args.output_copy)):
+            os.makedirs(os.path.dirname(args.output_copy))
+        shutil.copyfile(args.output, args.output_copy)
+
+if __name__ == '__main__':
+    args = parse_args()
+    gen_sine_table(args)

--- a/gr/lib/meson.build
+++ b/gr/lib/meson.build
@@ -23,6 +23,15 @@ constants_file = configure_file(input: 'constants.cc.in',
                           configuration: cdata,
                           install: false)
 
+#### Generate the Sin/Cos Tables
+srcs = custom_target('gen_sin_table',
+                        input : [],
+                        output : ['sine_table.h'], 
+                        command : ['python3', join_paths(meson.current_source_dir(), 'math','gen_sine_table.py'),
+                            '--output', '@OUTPUT0@'],  
+                        install : false)
+gr_deps += declare_dependency(sources : [srcs[0]] )
+
 
 runtime_sources = [
   constants_file,
@@ -55,7 +64,8 @@ runtime_sources = [
   # mmap requires librt - FIXME - handle this a conditional dependency
   'buffer_cpu_vmcirc_mmap_shm_open.cc',
   'buffer_net_zmq.cc',
-  'rpc_client_interface.cc'
+  'rpc_client_interface.cc',
+  'math/fxpt.cc'
 ]
 
 if USE_CUDA

--- a/gr/lib/runtime.cc
+++ b/gr/lib/runtime.cc
@@ -73,7 +73,7 @@ void runtime::initialize(graph_sptr fg)
     flowgraph::check_connections(fg);
     gr::logger_ptr d_logger, d_debug_logger;
     gr::configure_default_loggers(d_logger, d_debug_logger, fmt::format("runtime_init_{}", fg->name()));
-    d_logger->info("initialize {}", d_schedulers.size());
+    d_debug_logger->debug("initialize {}", d_schedulers.size());
 
     if (d_schedulers.size() == 1) {
         d_rtmon = std::make_shared<runtime_monitor>(

--- a/utils/blockbuilder/scripts/gen_meson.py
+++ b/utils/blockbuilder/scripts/gen_meson.py
@@ -88,15 +88,11 @@ def main():
                     print('   ' + y)
                     blockdirs.append(os.path.basename(y))
 
-            template = env.get_template('module.meson.build.j2')
-            rendered = template.render(module=module_name, blocks=blockdirs)
-            with open(meson_filename, 'w') as file:
-                print(f'generating: {meson_filename}')
-                file.write(rendered)
+            print(os.path.join(current_module_path,'enums.yml'))
+            has_enums = os.path.exists(os.path.join(current_module_path,'enums.yml'))
 
-            
             template = env.get_template('module.meson.build.j2')
-            rendered = template.render(module=module_name, blocks=blockdirs)
+            rendered = template.render(module=module_name, blocks=blockdirs, has_enums=has_enums)
             with open(meson_filename, 'w') as file:
                 print(f'generating: {meson_filename}')
                 file.write(rendered)

--- a/utils/blockbuilder/scripts/process_module_enums.py
+++ b/utils/blockbuilder/scripts/process_module_enums.py
@@ -1,0 +1,53 @@
+from jinja2 import Template, FileSystemLoader, DictLoader, Environment
+import os
+import argparse
+import yaml
+import shutil
+
+def argParse():
+    """Parses commandline args."""
+    desc=''
+    parser = argparse.ArgumentParser(description=desc)
+    parser.add_argument("--module")
+    parser.add_argument("--yaml_file")
+    parser.add_argument("--output_h")
+    parser.add_argument("--output_pybind")
+    parser.add_argument("--build_dir")
+
+    return parser.parse_args()
+
+def main():
+    args = argParse()
+
+    # env = Environment(loader = FileSystemLoader(os.path.join(os.path.dirname(os.path.abspath(__file__)),'..','templates'))
+    paths = []
+    paths.append(os.path.join(os.path.dirname(os.path.realpath(__file__)),'..','templates'))
+    paths.append(os.path.dirname(os.path.realpath(args.yaml_file)))
+    env = Environment(loader = FileSystemLoader(paths))
+
+    with open(args.yaml_file) as file:
+        d = yaml.load(file, Loader=yaml.FullLoader)
+
+        enums_h = os.path.join(args.build_dir, 'blocklib', args.module, os.path.basename(args.output_h))
+        enums_h_includedir = os.path.join(args.build_dir, 'blocklib', args.module, 'include', 'gnuradio', args.module, os.path.basename(args.output_h))
+        template = env.get_template('module_enums.h.j2')
+
+        rendered = template.render(enums=d, module=args.module)
+        with open(enums_h, 'w') as file:
+            print("generating " + enums_h)
+            file.write(rendered)
+
+        # Copy to the include dir
+        shutil.copyfile(enums_h, enums_h_includedir)                
+
+        if args.output_pybind:
+            filename = os.path.join(args.build_dir, 'blocklib', args.module, os.path.basename(args.output_pybind))
+            template = env.get_template('module_enums_pybind.cc.j2')
+
+            rendered = template.render(enums=d, module=args.module)
+            with open(filename, 'w') as file:
+                print("generating " + filename)
+                file.write(rendered)
+
+if __name__ == "__main__":
+    main()

--- a/utils/blockbuilder/templates/blockname_templated.cc.j2
+++ b/utils/blockbuilder/templates/blockname_templated.cc.j2
@@ -47,7 +47,7 @@ typename {{block}}<{% for key in typekeys -%}{{key['id']}}{{ ", " if not loop.la
 
     {% for p in parameters -%}
     {% if ('cotr' not in p or p['cotr']) and ('serializable' not in p or p['serializable'])%}
-    args.{{p['id']}} = pmtf::get_as<{{ 'std::vector<'+p['dtype']+'>' if 'container' in p and p['container'] == 'vector' else p['dtype']}}>(deserialize_param_to_pmt(json_obj["{{p['id']}}"].get<std::string>()));
+    args.{{p['id']}} = {{'('+p['dtype']+')' if p['is_enum']}}pmtf::get_as<{{ 'std::vector<'+p['dtype']+'>' if 'container' in p and p['container'] == 'vector' else 'int' if p['is_enum'] else p['dtype']}}>(deserialize_param_to_pmt(json_obj["{{p['id']}}"].get<std::string>()));
     {% endif %}
     {% endfor -%}
 
@@ -67,14 +67,22 @@ template <{% for key in typekeys -%}{{key['type']}} {{key['id']}}{{ ", " if not 
 template <{% for key in typekeys -%}{{key['type']}} {{key['id']}}{{ ", " if not loop.last }}{%endfor%}>
 void {{block}}<{% for key in typekeys -%}{{key['id']}}{{ ", " if not loop.last }}{%endfor%}>::set_{{p['id']}}({{ 'std::vector<'+p['dtype']+'>' if 'container' in p and p['container'] == 'vector' else p['dtype']}} {{p['id']}})
 {
-    return request_parameter_change(params::id_{{p['id']}}, {{p['id']}});
+    return request_parameter_change(params::id_{{p['id']}}, {{"(int)" if p['is_enum']}}{{p['id']}});
 }
 {% endif -%}
 {% if p['settable'] and not 'gettable' in p or p['gettable'] %}
 template <{% for key in typekeys -%}{{key['type']}} {{key['id']}}{{ ", " if not loop.last }}{%endfor%}>
 {{ 'std::vector<'+p['dtype']+'>' if 'container' in p and p['container'] == 'vector' else p['dtype']}} {{block}}<{% for key in typekeys -%}{{key['id']}}{{ ", " if not loop.last }}{%endfor%}>::{{p['id']}}()
 {
+{% if p['is_enum'] %}
+{% if 'container' in p and p['container'] == 'vector' %}
+    return pmtf::get_as<{{ 'std::vector<int>' }}>(request_parameter_query(params::id_{{p['id']}}));
+{% else %}
+    return ({{p['dtype']}}) pmtf::get_as<int>(request_parameter_query(params::id_{{p['id']}}));
+{% endif %}
+{% else %}
     return pmtf::get_as<{{ 'std::vector<'+p['dtype']+'>' if 'container' in p and p['container'] == 'vector' else p['dtype']}}>(request_parameter_query(params::id_{{p['id']}}));
+{% endif %}
 }
 {% endif %}
 {% endfor -%}

--- a/utils/blockbuilder/templates/macros.j2
+++ b/utils/blockbuilder/templates/macros.j2
@@ -14,7 +14,7 @@
 
 {% macro includes(includes) -%}
 {% for incl in includes %}
-#include <{{incl['value']}}>
+#include <{{incl}}>
 {% endfor %}
 {% endmacro %}
 
@@ -203,7 +203,7 @@ protected:
     //param_{{p['id']}} = {{ 'scalar' if 'container' not in p else p['container']}}_param<{{p['dtype']}}>::make(params::id_{{p['id']}}, 
     //    "{{p['id']}}"{{", args."+p['id'] if 'cotr' not in p or p['cotr']}});
     {%if 'cotr' not in p or p['cotr']%}
-    param_{{p['id']}} = std::make_shared<pmtf::pmt>({{"args."+p['id']}});
+    param_{{p['id']}} = std::make_shared<pmtf::pmt>({{'(int)' if p['is_enum']}}{{"args."+p['id']}});
     {%else%}
     param_{{p['id']}} = std::make_shared<pmtf::pmt>(pmtf::{{'scalar' if 'container' not in p else p['container']}}<{{p['dtype']}}>());
     {%endif%}

--- a/utils/blockbuilder/templates/module.meson.build.j2
+++ b/utils/blockbuilder/templates/module.meson.build.j2
@@ -12,6 +12,25 @@ subdir('include/gnuradio/{{module}}')
 {{module}}_pybind_names = []
 {{module}}_deps = []
 
+{% if has_enums -%}
+gen_srcs = custom_target('gen_{{module}}_enums',
+                        input : ['enums.yml'],
+                        output : ['enums.h','enums_pybind.cc'], 
+                        command : ['python3', join_paths(SCRIPTS_DIR,'process_module_enums.py'),
+                            '--module', '{{module}}',
+                            '--yaml_file', '@INPUT@', 
+                            '--output_h', '@OUTPUT0@', 
+                            '--output_pybind', '@OUTPUT1@', 
+                            '--build_dir', meson.build_root()],
+                        install : true,
+                        install_dir : ['include/gnuradio/{{module}}', false])
+
+if get_option('enable_python') 
+    {{module}}_pybind_sources += gen_srcs[1]
+    {{module}}_pybind_names += 'enums'
+endif
+{% endif %}
+
 # Individual block subdirectories
 {% for b in blocks -%}
 subdir('{{b}}')

--- a/utils/blockbuilder/templates/module_enums.h.j2
+++ b/utils/blockbuilder/templates/module_enums.h.j2
@@ -1,0 +1,13 @@
+{% import 'macros.j2' as macros -%}
+{{ macros.header() }}
+#pragma once
+
+namespace gr {
+namespace {{module}} {
+
+{% for e in enums %}
+    enum class {{e}} { {% for v in enums[e]['enumerators'] %}{{v['id']}}{{"="+v['value']|string() if 'value' in v }}{{"," if not loop.last}}{% endfor %} };
+{% endfor %}
+
+} // namespace {{ module }}
+} // namespace gr

--- a/utils/blockbuilder/templates/module_enums_pybind.cc.j2
+++ b/utils/blockbuilder/templates/module_enums_pybind.cc.j2
@@ -1,0 +1,16 @@
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+#include <gnuradio/{{module}}/enums.h>
+void bind_enums(py::module& m)
+{
+{% for e in enums %}
+    py::enum_<::gr::{{module}}::{{e}}>(m, "{{e}}")
+{% for v in enums[e]['enumerators'] -%}
+        .value("{{v['id']}}", ::gr::{{module}}::{{e}}::{{v['id']}})  
+{% endfor -%};
+
+    py::implicitly_convertible<int, ::gr::{{module}}::{{e}}>();
+{% endfor -%}
+}


### PR DESCRIPTION
Enums still need a bit of work to be cohesive, but this allows them to be defined at the module level via yaml since we need to specify them in yaml and use them in blocks across an entire module.

Question is: what is the best way to use them outside the module - e.g. dtv blocks use enums from gr::digital