### PR TITLE
meson: use system dependencies instead of subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -45,22 +45,28 @@ qt5_mod = import('qt5', required: false)
 qt5widgets_dep = dependency('qt5', modules : 'Widgets', required: false)
 qwt_dep = dependency('Qwt', method: 'cmake', cmake_module_path: join_paths(meson.source_root(), 'cmake','Modules'), required: false )
 
-# pmtf_dep = dependency('pmtf', version : '>=0.0.2')
-libpmtf = subproject('pmt')
-pmtf_dep = libpmtf.get_variable('pmtf_dep')
+# Use internal PMT by default – we expect some movement here still
+# But: offer option to look for external PMT lib; this should make package
+# Maintainers a bit happier
+if (get_option('external_pmt'))
+  # pmtf_dep = dependency('pmtf', version : '>=0.0.2')
+  pmtf_dep = dependency('pmtf', fallback : [ 'pmt' , 'pmtf_dep' ])
+else
+  libpmtf = subproject('pmt')
+  pmtf_dep = libpmtf.get_variable('pmtf_dep')
+endif
 
-libCLI11 = subproject('CLI11')
-CLI11_dep = libCLI11.get_variable('CLI11_dep')
-
-libjson = subproject('json')
-json_dep = libjson.get_variable('nlohmann_json_dep')
-
-libcpphttp = subproject('cpp-httplib')
-cpphttp_dep = libcpphttp.get_variable('cpp_httplib_dep')
-
+# Dependencies that can be used from system or subprojects
+## CLI11 : C++ command line parser
+CLI11_dep = dependency('CLI11', fallback : [ 'CLI11' , 'CLI11_dep' ])
+## NLohmann JSON: C++ JSON library
+json_dep = dependency('nlohmann_json', fallback : [ 'json', 'nlohmann_json_dep'])
+## cpp-httplib: C++11 single-file header-only cross platform HTTP/HTTPS library
+cpp_httplib_dep = dependency('httplib', fallback : [ 'cpp-httplib', 'cpp_httplib_dep' ])
+## cppzmq: C++ bindings for the ZeroMQ C library
 cmake = import('cmake')
-libcppzmq = cmake.subproject('cppzmq')
-cppzmq_dep = libcppzmq.dependency('cppzmq')
+cppzmq_dep = dependency('cppzmq', fallback : [ 'cppzmq' , 'cppzmq_dep' ] )
+
 
 if USE_CUDA
   libcusp = subproject('cusp')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,6 +4,9 @@ option('enable_cuda', type : 'boolean', value : false)
 option('enable_python', type : 'boolean', value : true)
 
 
+option('external_pmt', type : 'boolean', value : false)
+
+
 option('enable_gr_analog', type : 'boolean', value : true)
 option('enable_gr_blocks', type : 'boolean', value : true)
 option('enable_gr_digital', type : 'boolean', value : true)

--- a/subprojects/pmt.wrap
+++ b/subprojects/pmt.wrap
@@ -1,3 +1,3 @@
 [wrap-git]
-url = https://github.com/gnuradio/pmt
-revision = head
+url = https://github.com/marcusmueller/pmt
+revision = meson_use_system_cli11


### PR DESCRIPTION
Since PMT(f) is rather central, let's keep the default source the
subproject, but add an `external_pmt` meson option

This mirrors what https://github.com/gnuradio/pmt/pull/46 did to pmt (where it only affected CLI11 selection).

The motivation here is that we can now have a pmtf distro package, and let the newsched distro package build-depend on it. 