### PR TITLE
global: remove port_sptr, maintain ownership at block

### DIFF
--- a/blocklib/zeromq/pull_msg_source/pull_msg_source_cpu.cc
+++ b/blocklib/zeromq/pull_msg_source/pull_msg_source_cpu.cc
@@ -78,7 +78,7 @@ void pull_msg_source_cpu::readloop()
             std::stringbuf sb(buf);
             try {
                 auto m = pmtf::pmt::deserialize(sb);
-                _msg_out->post(m);
+                d_msg_out->post(m);
             } catch (...){ // Take out PMT specific exception for now
                 d_logger->error(std::string("Invalid PMT message: "));
             }

--- a/gr/include/gnuradio/block.h
+++ b/gr/include/gnuradio/block.h
@@ -46,8 +46,6 @@ protected:
     neighbor_interface_sptr p_scheduler = nullptr;
     std::map<std::string, int> d_param_str_map;
     std::map<int, std::string> d_str_param_map;
-    message_port_sptr _msg_param_update;
-    message_port_sptr _msg_system;
     std::shared_ptr<pyblock_detail> d_pyblock_detail;
     bool d_finished = false;
 

--- a/gr/include/gnuradio/block_work_io.h
+++ b/gr/include/gnuradio/block_work_io.h
@@ -13,10 +13,12 @@ namespace gr {
  * @brief Struct for passing all information needed for input data to block::work
  *
  */
-class block_work_input {
+class block_work_input
+{
 
 private:
     buffer_reader* _buffer;
+
 public:
     size_t n_items = 0;
     size_t n_consumed =
@@ -65,10 +67,10 @@ public:
 
     size_t n_produced =
         0; // output the number of items that were produced on the work() call
-    port_sptr port = nullptr;
-
+    port_ptr port = nullptr;
     block_work_output(int _n_items, buffer* p_buf_, port_sptr p = nullptr)
         : _buffer(p_buf_), n_items(_n_items), port(p)
+
     {
     }
     buffer& buf() { return *_buffer; }
@@ -227,12 +229,12 @@ private:
     io_vec_wrap<block_work_input> _inputs;
     io_vec_wrap<block_work_output> _outputs;
 
-    void add_input(port_sptr p)
+    void add_input(port_ptr p)
     {
         _inputs.append_item(block_work_input(0, p->get_buffer_reader(), p), p->name());
     }
 
-    void add_output(port_sptr p)
+    void add_output(port_ptr p)
     {
         _outputs.append_item(block_work_output(0, p->get_buffer(), p), p->name());
     }

--- a/gr/include/gnuradio/block_work_io.h
+++ b/gr/include/gnuradio/block_work_io.h
@@ -23,8 +23,8 @@ public:
     size_t n_items = 0;
     size_t n_consumed =
         0; // output the number of items that were consumed on the work() call
-    port_sptr port = nullptr;
-    block_work_input(int n_items_, buffer_reader* p_buf_, port_sptr p = nullptr)
+    port_ptr port = nullptr;
+    block_work_input(int n_items_, buffer_reader* p_buf_, port_ptr p = nullptr)
         : _buffer(p_buf_), n_items(n_items_), port(p)
     {
     }
@@ -68,7 +68,7 @@ public:
     size_t n_produced =
         0; // output the number of items that were produced on the work() call
     port_ptr port = nullptr;
-    block_work_output(int _n_items, buffer* p_buf_, port_sptr p = nullptr)
+    block_work_output(int _n_items, buffer* p_buf_, port_ptr p = nullptr)
         : _buffer(p_buf_), n_items(_n_items), port(p)
 
     {

--- a/gr/include/gnuradio/edge.h
+++ b/gr/include/gnuradio/edge.h
@@ -32,20 +32,20 @@ public:
  * @brief Endpoint between ports associated with nodes
  *
  */
-class GR_RUNTIME_API node_endpoint : public endpoint<node_sptr, port_sptr>
+class GR_RUNTIME_API node_endpoint : public endpoint<node_sptr, port_ptr>
 {
 private:
     node_sptr d_node;
-    port_sptr d_port;
+    port_ptr d_port;
 
 public:
     node_endpoint();
-    node_endpoint(node_sptr node, port_sptr port);
+    node_endpoint(node_sptr node, port_ptr port);
     node_endpoint(const node_endpoint& n);
 
     ~node_endpoint() override{};
     node_sptr node() const;
-    port_sptr port() const;
+    port_ptr port() const;
     std::string identifier() const;
 };
 
@@ -81,12 +81,12 @@ public:
         return std::make_shared<edge>(src, dst);
     }
     static sptr
-    make(node_sptr src_blk, port_sptr src_port, node_sptr dst_blk, port_sptr dst_port)
+    make(node_sptr src_blk, port_ptr src_port, node_sptr dst_blk, port_ptr dst_port)
     {
         return std::make_shared<edge>(src_blk, src_port, dst_blk, dst_port);
     }
     edge(const node_endpoint& src, const node_endpoint& dst);
-    edge(node_sptr src_blk, port_sptr src_port, node_sptr dst_blk, port_sptr dst_port);
+    edge(node_sptr src_blk, port_ptr src_port, node_sptr dst_blk, port_ptr dst_port);
     virtual ~edge(){};
     node_endpoint src() const;
     node_endpoint dst() const;

--- a/gr/include/gnuradio/flat_graph.h
+++ b/gr/include/gnuradio/flat_graph.h
@@ -16,7 +16,7 @@ private:
     block_sptr d_block;
 
 public:
-    block_endpoint(block_sptr block, port_sptr port)
+    block_endpoint(block_sptr block, port_ptr port)
         : node_endpoint(block, port), d_block(block)
     {
     }
@@ -233,7 +233,7 @@ public:
         return fg;
     }
 
-    block_vector_t calc_downstream_blocks(block_sptr block, port_sptr port);
+    block_vector_t calc_downstream_blocks(block_sptr block, port_ptr port);
 
 protected:
     block_vector_t d_blocks;

--- a/gr/include/gnuradio/graph.h
+++ b/gr/include/gnuradio/graph.h
@@ -64,7 +64,7 @@ public:
 
     // }
     node_vector_t calc_used_nodes();
-    edge_vector_t find_edge(port_sptr port);
+    edge_vector_t find_edge(port_ptr port);
 };
 
 using graph_sptr = std::shared_ptr<graph>;

--- a/gr/include/gnuradio/hier_block.h
+++ b/gr/include/gnuradio/hier_block.h
@@ -27,7 +27,6 @@ public:
     virtual ~hier_block() { gnuradio::detail::sptr_magic::cancel_initial_sptr(this); }
     node_sptr self() { return shared_from_this(); }
     // add_port becomes public only for hier_block
-    void add_port(port_sptr p) { block::add_port(p); }
     edge_sptr connect(const node_endpoint& src, const node_endpoint& dst)
     {
         if (src.node().get() == this) { // connecting to self input ports
@@ -60,14 +59,14 @@ public:
             dst_direction = port_direction_t::OUTPUT;
         }
 
-        port_sptr src_port =
+        port_ptr src_port =
             (src_node == nullptr)
                 ? nullptr
                 : src_node->get_port(src_port_index,
                                      port_type_t::STREAM,
                                      src_direction); // for hier block it is reversed
 
-        port_sptr dst_port =
+        port_ptr dst_port =
             (dst_node == nullptr)
                 ? nullptr
                 : dst_node->get_port(dst_port_index, port_type_t::STREAM, dst_direction);

--- a/gr/include/gnuradio/message_port_proxy.h
+++ b/gr/include/gnuradio/message_port_proxy.h
@@ -10,8 +10,8 @@ namespace gr {
 class message_port_proxy_upstream : public port_interface
 {
 public:
-    using sptr = std::shared_ptr<message_port_proxy_upstream>;
-    static sptr make() { return std::make_shared<message_port_proxy_upstream>(); }
+    using uptr = std::unique_ptr<message_port_proxy_upstream>;
+    static uptr make() { return std::make_unique<message_port_proxy_upstream>(); }
     message_port_proxy_upstream() : _context(1), _socket(_context, zmq::socket_type::push)
     {
         _socket.set(zmq::sockopt::sndhwm, 1);
@@ -53,10 +53,10 @@ private:
 class message_port_proxy_downstream : public port_interface
 {
 public:
-    using sptr = std::shared_ptr<message_port_proxy_downstream>;
-    static sptr make(int port)
+    using uptr = std::unique_ptr<message_port_proxy_downstream>;
+    static uptr make(int port)
     {
-        return std::make_shared<message_port_proxy_downstream>(port);
+        return std::make_unique<message_port_proxy_downstream>(port);
     }
     message_port_proxy_downstream(int port)
         : _context(1), _socket(_context, zmq::socket_type::pull), _port(port)
@@ -112,7 +112,7 @@ public:
         });
         t.detach();
     }
-    void set_gr_port(port_interface_sptr p) { _grport = p; };
+    void set_gr_port(port_interface_ptr p) { _grport = p; };
     void push_message(scheduler_message_sptr msg) override
     {
         throw std::runtime_error(
@@ -120,7 +120,7 @@ public:
     }
 
 private:
-    port_interface_sptr _grport = nullptr;
+    port_interface_ptr _grport = nullptr;
 
     zmq::context_t _context;
     zmq::socket_t _socket;

--- a/gr/include/gnuradio/port_interface.h
+++ b/gr/include/gnuradio/port_interface.h
@@ -11,6 +11,6 @@ public:
     virtual ~port_interface() = default;
 };
 
-using port_interface_sptr = std::shared_ptr<port_interface>;
+using port_interface_ptr = port_interface*;
 
 } // namespace gr

--- a/gr/include/gnuradio/python_block.h
+++ b/gr/include/gnuradio/python_block.h
@@ -47,8 +47,6 @@ public:
 
     bool start(void) override;
     bool stop(void) override;
-
-    void add_port(port_sptr p) { node::add_port(p); }
 };
 
 class GR_RUNTIME_API python_sync_block : virtual public gr::sync_block
@@ -69,8 +67,6 @@ public:
 
     bool start(void) override;
     bool stop(void) override;
-
-    void add_port(port_sptr p) { node::add_port(p); }
 };
 
 } /* namespace gr */

--- a/gr/lib/block.cc
+++ b/gr/lib/block.cc
@@ -16,15 +16,15 @@ block::block(const std::string& name, const std::string& module)
       d_tag_propagation_policy(tag_propagation_policy_t::TPP_ALL_TO_ALL)
 {
     // {# add message handler port for parameter updates#}
-    _msg_param_update = message_port::make("param_update", port_direction_t::INPUT);
-    _msg_param_update->register_callback(
+    auto msg_param_update = message_port::make("param_update", port_direction_t::INPUT);
+    msg_param_update->register_callback(
         [this](pmtf::pmt msg) { this->handle_msg_param_update(msg); });
-    add_port(_msg_param_update);
+    add_port(std::move(msg_param_update));
 
-    _msg_system = message_port::make("system", port_direction_t::INPUT);
-    _msg_system->register_callback(
+    auto msg_system = message_port::make("system", port_direction_t::INPUT);
+    msg_system->register_callback(
         [this](pmtf::pmt msg) { this->handle_msg_system(msg); });
-    add_port(_msg_system);
+    add_port(std::move(msg_system));
 }
 
 void block::set_pyblock_detail(std::shared_ptr<pyblock_detail> p)

--- a/gr/lib/edge.cc
+++ b/gr/lib/edge.cc
@@ -3,20 +3,20 @@
 namespace gr {
 
 node_endpoint::node_endpoint() : endpoint(){};
-node_endpoint::node_endpoint(node_sptr node, port_sptr port)
-    : endpoint<node_sptr, port_sptr>(node, port), d_node(node), d_port(port)
+node_endpoint::node_endpoint(node_sptr node, port_ptr port)
+    : endpoint<node_sptr, port_ptr>(node, port), d_node(node), d_port(port)
 {
 }
 
 node_endpoint::node_endpoint(const node_endpoint& n)
-    : endpoint<node_sptr, port_sptr>(n.node(), n.port())
+    : endpoint<node_sptr, port_ptr>(n.node(), n.port())
 {
     d_node = n.node();
     d_port = n.port();
 }
 
 node_sptr node_endpoint::node() const { return d_node; }
-port_sptr node_endpoint::port() const { return d_port; }
+port_ptr node_endpoint::port() const { return d_port; }
 std::string node_endpoint::identifier() const
 {
     if (d_node)
@@ -26,7 +26,7 @@ std::string node_endpoint::identifier() const
 };
 
 edge::edge(const node_endpoint& src, const node_endpoint& dst) : _src(src), _dst(dst) {}
-edge::edge(node_sptr src_blk, port_sptr src_port, node_sptr dst_blk, port_sptr dst_port)
+edge::edge(node_sptr src_blk, port_ptr src_port, node_sptr dst_blk, port_ptr dst_port)
     : _src(node_endpoint(src_blk, src_port)), _dst(node_endpoint(dst_blk, dst_port))
 {
 }

--- a/gr/lib/flat_graph.cc
+++ b/gr/lib/flat_graph.cc
@@ -31,7 +31,7 @@ port_vector_t flat_graph::calc_used_ports(block_sptr block, bool check_inputs)
             tmp.push_back(p->src().port());
     }
 
-    return unique_vector<port_sptr>(tmp);
+    return unique_vector<port_ptr>(tmp);
 }
 
 edge_vector_t flat_graph::calc_connections(block_sptr block, bool check_inputs)
@@ -52,7 +52,7 @@ edge_vector_t flat_graph::calc_connections(block_sptr block, bool check_inputs)
     return result; // assumes no duplicates
 }
 
-block_vector_t flat_graph::calc_downstream_blocks(block_sptr block, port_sptr port)
+block_vector_t flat_graph::calc_downstream_blocks(block_sptr block, port_ptr port)
 {
     block_vector_t tmp;
 

--- a/gr/lib/flowgraph.cc
+++ b/gr/lib/flowgraph.cc
@@ -8,12 +8,12 @@ namespace gr {
 
 flowgraph::flowgraph(const std::string& name) { set_alias(name); }
 
-size_t get_port_itemsize(port_sptr port)
+size_t get_port_itemsize(port_ptr port)
 {
     size_t size = 0;
     if (!port->connected_ports().empty()) {
         auto cp = port->connected_ports()[0];
-        auto p = std::dynamic_pointer_cast<port_base>(cp);
+        auto p = dynamic_cast<port_ptr>(cp);
         // use data_size since this includes vector sizing
         if (p)
             size = p->itemsize();
@@ -21,12 +21,12 @@ size_t get_port_itemsize(port_sptr port)
     return size;
 }
 
-std::string get_port_format_descriptor(port_sptr port)
+std::string get_port_format_descriptor(port_ptr port)
 {
     std::string fd = "";
     if (!port->connected_ports().empty()) {
         auto cp = port->connected_ports()[0];
-        auto p = std::dynamic_pointer_cast<port_base>(cp);
+        auto p = dynamic_cast<port_ptr>(cp);
         if (p)
             fd = p->format_descriptor();
     }

--- a/gr/lib/graph.cc
+++ b/gr/lib/graph.cc
@@ -53,9 +53,9 @@ edge_sptr graph::connect(const node_endpoint& src, const node_endpoint& dst)
 
     // Give the underlying port objects information about the connected ports
     if (src.port())
-        src.port()->connect(dst.port());
+        src.port()->connect(static_cast<port_interface_ptr>(dst.port()));
     if (dst.port())
-        dst.port()->connect(src.port());
+        dst.port()->connect(static_cast<port_interface_ptr>(src.port()));
 
     return newedge;
 }
@@ -65,7 +65,7 @@ edge_sptr graph::connect(node_sptr src_node,
                          node_sptr dst_node,
                          unsigned int dst_port_index)
 {
-    port_sptr src_port = (src_node == nullptr)
+    port_ptr src_port = (src_node == nullptr)
                              ? nullptr
                              : src_node->get_port(src_port_index,
                                                   port_type_t::STREAM,
@@ -73,7 +73,7 @@ edge_sptr graph::connect(node_sptr src_node,
     // if (src_port == nullptr)
     //     throw std::invalid_argument("Source Port not found");
 
-    port_sptr dst_port = (dst_node == nullptr)
+    port_ptr dst_port = (dst_node == nullptr)
                              ? nullptr
                              : dst_node->get_port(dst_port_index,
                                                   port_type_t::STREAM,
@@ -89,12 +89,12 @@ edge_sptr graph::connect(node_sptr src_node,
                          node_sptr dst_node,
                          const std::string& dst_port_name)
 {
-    port_sptr src_port =
+    port_ptr src_port =
         (src_node == nullptr) ? nullptr : src_node->get_port(src_port_name);
     // if (src_port == nullptr)
     // throw std::invalid_argument("Source Port not found");
 
-    port_sptr dst_port =
+    port_ptr dst_port =
         (dst_node == nullptr) ? nullptr : dst_node->get_port(dst_port_name);
     // if (dst_port == nullptr)
     // throw std::invalid_argument("Destination port not found");
@@ -192,7 +192,7 @@ node_vector_t graph::all_nodes()
     return unique_vector<node_sptr>(tmp);
 }
 
-edge_vector_t graph::find_edge(port_sptr port)
+edge_vector_t graph::find_edge(port_ptr port)
 {
     edge_vector_t ret;
     for (auto& e : edges()) {

--- a/gr/lib/port.cc
+++ b/gr/lib/port.cc
@@ -1,7 +1,7 @@
 #include <gnuradio/port.h>
 
 namespace gr {
-port_sptr port_base::make(const std::string& name,
+port_base::uptr port_base::make(const std::string& name,
                           const port_direction_t direction,
                           const param_type_t data_type,
                           const port_type_t port_type,
@@ -9,7 +9,7 @@ port_sptr port_base::make(const std::string& name,
                           const bool optional,
                           const int multiplicity)
 {
-    return std::make_shared<port_base>(
+    return std::make_unique<port_base>(
         name, direction, data_type, port_type, shape, optional, multiplicity);
 }
 
@@ -95,16 +95,17 @@ void port_base::push_message(scheduler_message_sptr msg)
         // of the remote node will get called here
         // in which case, it really needs to signal to the remote
         // flowgraph -- how to do that???
+        //FIXME - make a logging message or exception
         std::cout << "port has no parent interface" << std::endl;
         // throw std::runtime_error("port has no parent interface");
     }
 }
 
-void port_base::connect(port_interface_sptr other_port)
+void port_base::connect(port_interface_ptr other_port)
 {
 
-    auto pred = [other_port](port_interface_sptr p) { return (p == other_port); };
-    std::vector<port_interface_sptr>::iterator it =
+    auto pred = [other_port](port_interface_ptr p) { return (p == other_port); };
+    std::vector<port_interface_ptr>::iterator it =
         std::find_if(std::begin(_connected_ports), std::end(_connected_ports), pred);
 
     if (it == std::end(_connected_ports) || !other_port) { // allow nullptr to be added
@@ -113,20 +114,19 @@ void port_base::connect(port_interface_sptr other_port)
     }
 }
 
-void port_base::disconnect(port_interface_sptr other_port)
+void port_base::disconnect(port_interface_ptr other_port)
 {
     std::remove(_connected_ports.begin(), _connected_ports.end(), other_port);
 }
 
 template <typename T>
-std::shared_ptr<port<T>> port<T>::make(const std::string& name,
+std::unique_ptr<port<T>> port<T>::make(const std::string& name,
                                        const port_direction_t direction,
                                        const std::vector<size_t>& shape,
                                        const bool optional,
                                        const int multiplicity)
 {
-    return std::shared_ptr<port<T>>(
-        new port<T>(name, direction, shape, optional, multiplicity));
+    return std::make_unique<port<T>>(name, direction, shape, optional, multiplicity);
 }
 
 template <typename T>
@@ -147,15 +147,13 @@ port<T>::port(const std::string& name,
 {
 }
 
-
-std::shared_ptr<untyped_port> untyped_port::make(const std::string& name,
+untyped_port::uptr untyped_port::make(const std::string& name,
                                                  const port_direction_t direction,
                                                  const size_t itemsize,
                                                  const bool optional,
                                                  const int multiplicity)
 {
-    return std::shared_ptr<untyped_port>(
-        new untyped_port(name, direction, itemsize, optional, multiplicity));
+    return std::make_unique<untyped_port>(name, direction, itemsize, optional, multiplicity);
 }
 untyped_port::untyped_port(const std::string& name,
                            const port_direction_t direction,
@@ -166,12 +164,12 @@ untyped_port::untyped_port(const std::string& name,
 {
 }
 
-std::shared_ptr<message_port> message_port::make(const std::string& name,
+message_port::uptr message_port::make(const std::string& name,
                                                  const port_direction_t direction,
                                                  const bool optional,
                                                  const int multiplicity)
 {
-    return std::make_shared<message_port>(name, direction, optional, multiplicity);
+    return std::make_unique<message_port>(name, direction, optional, multiplicity);
 }
 message_port::message_port(const std::string& name,
                            const port_direction_t direction,

--- a/gr/lib/python_block.cc
+++ b/gr/lib/python_block.cc
@@ -33,7 +33,7 @@ work_return_code_t python_block::work(work_io& wio)
 {
     py::gil_scoped_acquire acquire;
 
-    py::object ret = d_py_handle.attr("handle_work")(wio);
+    py::object ret = d_py_handle.attr("handle_work")(&wio);
 
     return ret.cast<work_return_code_t>();
 }

--- a/gr/python/gr/bindings/edge_pybind.cc
+++ b/gr/python/gr/bindings/edge_pybind.cc
@@ -28,7 +28,7 @@ void bind_edge(py::module& m)
 
     py::class_<edge, std::shared_ptr<edge>>(m, "edge")
         .def(py::init(
-            [](gr::node_sptr a, gr::port_sptr b, gr::node_sptr c, gr::port_sptr d) {
+            [](gr::node_sptr a, gr::port_ptr b, gr::node_sptr c, gr::port_ptr d) {
                 return ::gr::edge::make(a, b, c, d);
             }))
         .def("set_custom_buffer", &edge::set_custom_buffer)

--- a/gr/python/gr/bindings/hier_block_pybind.cc
+++ b/gr/python/gr/bindings/hier_block_pybind.cc
@@ -23,7 +23,6 @@ void bind_hier_block(py::module& m)
     py::class_<gr::hier_block, gr::block, gr::node, std::shared_ptr<gr::hier_block>>(
         m, "hier_block")
         .def(py::init<const std::string&>())
-        .def("add_port", &gr::hier_block::add_port)
         .def("connect",
              py::overload_cast<std::shared_ptr<gr::node>,
                                unsigned int,

--- a/gr/python/gr/bindings/message_port_proxy_pybind.cc
+++ b/gr/python/gr/bindings/message_port_proxy_pybind.cc
@@ -25,14 +25,14 @@ void bind_message_port_proxy(py::module& m)
 
     py::class_<gr::message_port_proxy_upstream,
                gr::port_interface,
-               std::shared_ptr<gr::message_port_proxy_upstream>>(
+               std::unique_ptr<gr::message_port_proxy_upstream>>(
         m, "message_port_proxy_upstream")
         .def(py::init(&gr::message_port_proxy_upstream::make))
         .def("connect", &gr::message_port_proxy_upstream::connect);
 
     py::class_<gr::message_port_proxy_downstream,
                gr::port_interface,
-               std::shared_ptr<gr::message_port_proxy_downstream>>(
+               std::unique_ptr<gr::message_port_proxy_downstream>>(
         m, "message_port_proxy_downstream")
         .def(py::init(&gr::message_port_proxy_downstream::make))
         .def("port", &gr::message_port_proxy_downstream::port)

--- a/gr/python/gr/bindings/node_pybind.cc
+++ b/gr/python/gr/bindings/node_pybind.cc
@@ -13,21 +13,145 @@ void bind_node(py::module& m)
 {
     using node = ::gr::node;
 
+    // using port_base = ::gr::port_base;
+    using port_f = ::gr::port<float>;
+    using port_c = ::gr::port<gr_complex>;
+    using port_s = ::gr::port<int16_t>;
+    using port_i = ::gr::port<int32_t>;
+    using port_b = ::gr::port<uint8_t>;
+
+    using message_port = ::gr::message_port;
+    using untyped_port = ::gr::untyped_port;
+
     py::class_<node, std::shared_ptr<node>>(m, "node")
 
         .def("name", &node::name)
         .def("alias", &node::alias)
+        // .def("add_port",
+        //      [](node& self, gr::port_uptr& pt) {
+        //          self.add_port(std::move(pt));
+        //      })
         .def("get_port",
              py::overload_cast<unsigned int, gr::port_type_t, gr::port_direction_t>(
-                 &gr::node::get_port))
+                 &gr::node::get_port),
+             py::return_value_policy::reference)
         .def("get_port",
-             py::overload_cast<const std::string&>(
-                 &gr::node::get_port))
-        .def("get_message_port", &node::get_message_port)
+             py::overload_cast<const std::string&>(&gr::node::get_port),
+             py::return_value_policy::reference)
+        .def("get_message_port",
+             &node::get_message_port,
+             py::return_value_policy::reference)
         .def("set_rpc", &node::set_rpc)
         .def("rpc_client", &node::rpc_client)
         .def("rpc_name", &node::rpc_name)
         .def("input_ports", &node::input_ports)
         .def("output_ports", &node::output_ports)
+        .def(
+            "add_port_f",
+            [](node& self,
+               const std::string& name,
+               gr::port_direction_t dir,
+               std::vector<size_t> shape = { 1 },
+               bool optional = false,
+               size_t multiplicity = 1) {
+                self.add_port(port_f::make(name, dir, shape, optional, multiplicity));
+            },
+            py::arg("name"),
+            py::arg("direction"),
+            py::arg("shape") = std::vector<size_t>{ 1 },
+            py::arg("optional") = false,
+            py::arg("multiplicity") = 1)
+        .def(
+            "add_port_c",
+            [](node& self,
+               const std::string& name,
+               gr::port_direction_t dir,
+               std::vector<size_t> shape = { 1 },
+               bool optional = false,
+               size_t multiplicity = 1) {
+                self.add_port(port_c::make(name, dir, shape, optional, multiplicity));
+            },
+            py::arg("name"),
+            py::arg("direction"),
+            py::arg("shape") = std::vector<size_t>{ 1 },
+            py::arg("optional") = false,
+            py::arg("multiplicity") = 1)
+        .def(
+            "add_port_s",
+            [](node& self,
+               const std::string& name,
+               gr::port_direction_t dir,
+               std::vector<size_t> shape = { 1 },
+               bool optional = false,
+               size_t multiplicity = 1) {
+                self.add_port(port_s::make(name, dir, shape, optional, multiplicity));
+            },
+            py::arg("name"),
+            py::arg("direction"),
+            py::arg("shape") = std::vector<size_t>{ 1 },
+            py::arg("optional") = false,
+            py::arg("multiplicity") = 1)
+        .def(
+            "add_port_i",
+            [](node& self,
+               const std::string& name,
+               gr::port_direction_t dir,
+               std::vector<size_t> shape = { 1 },
+               bool optional = false,
+               size_t multiplicity = 1) {
+                self.add_port(port_i::make(name, dir, shape, optional, multiplicity));
+            },
+            py::arg("name"),
+            py::arg("direction"),
+            py::arg("shape") = std::vector<size_t>{ 1 },
+            py::arg("optional") = false,
+            py::arg("multiplicity") = 1)
+        .def(
+            "add_port_b",
+            [](node& self,
+               const std::string& name,
+               gr::port_direction_t dir,
+               std::vector<size_t> shape = { 1 },
+               bool optional = false,
+               size_t multiplicity = 1) {
+                self.add_port(port_b::make(name, dir, shape, optional, multiplicity));
+            },
+            py::arg("name"),
+            py::arg("direction"),
+            py::arg("shape") = std::vector<size_t>{ 1 },
+            py::arg("optional") = false,
+            py::arg("multiplicity") = 1)
+        .def(
+            "add_message_port",
+            [](node& self,
+               const std::string& name,
+               const gr::port_direction_t direction,
+               const bool optional = false,
+               const int multiplicity = 1) {
+                self.add_port(
+                    message_port::make(name, direction, optional, multiplicity));
+            },
+            py::arg("name"),
+            py::arg("direction"),
+            py::arg("optional") = false,
+            py::arg("multiplicity") = 1)
+        .def(
+            "add_untyped_port",
+            [](node& self,
+               const std::string& name,
+               const gr::port_direction_t direction,
+               const size_t itemsize,
+               const bool optional = false,
+               const int multiplicity) {
+                self.add_port(untyped_port::make(
+                    name, direction, itemsize, optional, multiplicity));
+            },
+            py::arg("name"),
+            py::arg("direction"),
+            py::arg("itemsize"),
+            py::arg("optional") = false,
+            py::arg("multiplicity") = 1)
+
+
         ;
 }

--- a/gr/python/gr/bindings/port_pybind.cc
+++ b/gr/python/gr/bindings/port_pybind.cc
@@ -21,10 +21,10 @@ void bind_port(py::module& m)
     using message_port = ::gr::message_port;
     using untyped_port = ::gr::untyped_port;
 
-    py::class_<gr::port_interface, std::shared_ptr<gr::port_interface>>(m,
+    py::class_<gr::port_interface, std::unique_ptr<gr::port_interface>>(m,
                                                                         "port_interface");
 
-    py::class_<port_base, gr::port_interface, std::shared_ptr<port_base>>(m, "port_base")
+    py::class_<port_base, gr::port_interface, std::unique_ptr<port_base>>(m, "port_base")
         .def("format_descriptor", &gr::port_base::format_descriptor)
         .def("shape", &gr::port_base::shape)
         .def("index", &gr::port_base::index)
@@ -34,56 +34,19 @@ void bind_port(py::module& m)
         .def("type", &gr::port_base::type)
         ;
 
-    py::class_<port_f, port_base, std::shared_ptr<port_f>>(m, "port_f")
-        .def(py::init(&port_f::make),
-             py::arg("name"),
-             py::arg("direction"),
-             py::arg("shape") = std::vector<size_t>{ 1 },
-             py::arg("optional") = false,
-             py::arg("multiplicity") = 1);
-    py::class_<port_c, port_base, std::shared_ptr<port_c>>(m, "port_c")
-        .def(py::init(&port_c::make),
-             py::arg("name"),
-             py::arg("direction"),
-             py::arg("shape") = std::vector<size_t>{ 1 },
-             py::arg("optional") = false,
-             py::arg("multiplicity") = 1);
-    py::class_<port_s, port_base, std::shared_ptr<port_s>>(m, "port_s")
-        .def(py::init(&port_s::make),
-             py::arg("name"),
-             py::arg("direction"),
-             py::arg("shape") = std::vector<size_t>{ 1 },
-             py::arg("optional") = false,
-             py::arg("multiplicity") = 1);
-    py::class_<port_i, port_base, std::shared_ptr<port_i>>(m, "port_i")
-        .def(py::init(&port_i::make),
-             py::arg("name"),
-             py::arg("direction"),
-             py::arg("shape") = std::vector<size_t>{ 1 },
-             py::arg("optional") = false,
-             py::arg("multiplicity") = 1);
-    py::class_<port_b, port_base, std::shared_ptr<port_b>>(m, "port_b")
-        .def(py::init(&port_b::make),
-             py::arg("name"),
-             py::arg("direction"),
-             py::arg("shape") = std::vector<size_t>{ 1 },
-             py::arg("optional") = false,
-             py::arg("multiplicity") = 1);
+    py::class_<port_f, port_base, std::unique_ptr<port_f>>(m, "port_f");
+    py::class_<port_c, port_base, std::unique_ptr<port_c>>(m, "port_c");
+    py::class_<port_s, port_base, std::unique_ptr<port_s>>(m, "port_s");
+    py::class_<port_i, port_base, std::unique_ptr<port_i>>(m, "port_i");
+    py::class_<port_b, port_base, std::unique_ptr<port_b>>(m, "port_b");
 
     py::class_<message_port,
                port_base,
                gr::port_interface,
-               std::shared_ptr<message_port>>(m, "message_port")
+               std::unique_ptr<message_port>>(m, "message_port")
         .def("post", &message_port::post);
 
-    py::class_<untyped_port, port_base, std::shared_ptr<untyped_port>>(m, "untyped_port")
-        .def(py::init(&untyped_port::make),
-             py::arg("name"),
-             py::arg("direction"),
-             py::arg("itemsize"),
-             py::arg("optional") = false,
-             py::arg("multiplicity") = 1);
-
+    py::class_<untyped_port, port_base, std::unique_ptr<untyped_port>>(m, "untyped_port");
 
     py::enum_<gr::port_direction_t>(m, "port_direction_t")
         .value("INPUT", gr::port_direction_t::INPUT)

--- a/gr/python/gr/bindings/python_block_pybind.cc
+++ b/gr/python/gr/bindings/python_block_pybind.cc
@@ -25,8 +25,7 @@ void bind_python_block(py::module& m)
         m, "python_block")
 
         .def(py::init(&python_block::make), py::arg("p"), py::arg("name"))
-
-        .def("add_port", &python_block::add_port);
+        ;
 
     using python_sync_block = gr::python_sync_block;
     py::class_<python_sync_block,
@@ -35,9 +34,7 @@ void bind_python_block(py::module& m)
                std::shared_ptr<python_sync_block>>(m, "python_sync_block")
 
         .def(py::init(&python_sync_block::make), py::arg("p"), py::arg("name"))
-
-        .def("add_port", &python_sync_block::add_port);
-
+        ;
 
     py::enum_<gr::py_block_t>(m, "py_block_t")
         .value("PY_BLOCK_GENERAL", gr::PY_BLOCK_GENERAL)

--- a/test/qa_hier_block.py
+++ b/test/qa_hier_block.py
@@ -6,9 +6,9 @@ class hwrap(gr.hier_block):
     def __init__(self):
         gr.hier_block.__init__(self, 'hwrap')
 
-        self.add_port(gr.port_f("hin", gr.INPUT))
-        self.add_port(gr.port_f("hout1", gr.OUTPUT))
-        self.add_port(gr.port_f("hout2", gr.OUTPUT))
+        self.add_port_f("hin", gr.INPUT)
+        self.add_port_f("hout1", gr.OUTPUT)
+        self.add_port_f("hout2", gr.OUTPUT)
 
         cp1 = streamops.copy(gr.sizeof_float)
         cp2 = streamops.copy(gr.sizeof_float)

--- a/test/qa_python_block.py
+++ b/test/qa_python_block.py
@@ -18,9 +18,9 @@ class add_2_f32_1_f32(gr.sync_block):
             self,
             name="add 2 f32")
 
-        self.add_port(gr.port_f("in1", gr.INPUT, shape))
-        self.add_port(gr.port_f("in2", gr.INPUT, shape))
-        self.add_port(gr.port_f("out", gr.OUTPUT, shape))
+        self.add_port_f("in1", gr.INPUT, shape)
+        self.add_port_f("in2", gr.INPUT, shape)
+        self.add_port_f("out", gr.OUTPUT, shape)
 
     def work(self, wio):
         noutput_items = wio.outputs()[0].n_items
@@ -41,9 +41,9 @@ class add_2_f32_1_f32_named(gr.sync_block):
             self,
             name="add 2 f32 named")
 
-        self.add_port(gr.port_f("in1", gr.INPUT, shape))
-        self.add_port(gr.port_f("in2", gr.INPUT, shape))
-        self.add_port(gr.port_f("out", gr.OUTPUT, shape))
+        self.add_port_f("in1", gr.INPUT, shape)
+        self.add_port_f("in2", gr.INPUT, shape)
+        self.add_port_f("out", gr.OUTPUT, shape)
 
     def work(self, wio):
         out = wio.outputs()["out"]

--- a/utils/blockbuilder/templates/macros.j2
+++ b/utils/blockbuilder/templates/macros.j2
@@ -85,15 +85,15 @@ class {{ block }} : virtual public {{blocktype}}{#{{',' if inherits != ''}}  {{ 
         {% endif %}
         {% else %}
         {% if port['direction'] == 'input' %}
-        _msg_{{port['id']}} = message_port::make(
+        auto msg_{{port['id']}} = message_port::make(
             "{{port['id']}}", port_direction_t::INPUT, {{port['optional']|lower()}});
-        _msg_{{port['id']}}->register_callback([this](pmtf::pmt msg) { this->handle_msg_{{port['id']}}(msg); });
-        add_port(_msg_{{port['id']}});
+        msg_{{port['id']}}->register_callback([this](pmtf::pmt msg) { this->handle_msg_{{port['id']}}(msg); });
         {% else %}
-        _msg_{{port['id']}} = message_port::make(
+        auto msg_{{port['id']}} = message_port::make(
             "{{port['id']}}", port_direction_t::OUTPUT, {{port['optional']|lower()}});
-        add_port(_msg_{{port['id']}});
         {% endif %}
+        add_port(std::move(msg_{{port['id']}}));
+        d_msg_{{port['id']}} = this->get_message_port("{{port['id']}}");
         {% endif -%}
         {% endfor %}
 {% endmacro %}
@@ -137,7 +137,7 @@ class {{ block }} : virtual public {{blocktype}}{#{{',' if inherits != ''}}  {{ 
 
 {% macro message_ports(ports) -%}
     {% for port in ports %}{% if port['domain'] == 'message' -%}
-        message_port_sptr _msg_{{port['id']}};
+        message_port_ptr d_msg_{{port['id']}};
     {% endif %}{% endfor %}
     {% for port in ports %}{% if port['domain'] == 'message' and port['direction'] == 'input' -%}
     virtual void handle_msg_{{port['id']}}(pmtf::pmt msg) {} //= 0;


### PR DESCRIPTION
Prior to this PR, port was maintained as an sptr, but ownership is clearly with the block that has the port.

This changes the ptr type to unique_ptr, and forces a std::move to add_port to the block.  This is all done in autogenerated code, so it shouldn't really make an impact to the user.

The only user facing change is that for python blocks, we cannot create a port object, then add it to a block in the constructor.  So, the add_port methods are made to mirror the port init methods